### PR TITLE
feat: scaffold QML control library

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+path/to/binary1
+path/to/binary2

--- a/README.md
+++ b/README.md
@@ -33,9 +33,9 @@ YunPan/
 ## 功能特性
 
 - **主题一键切换**：`ThemeManager` 单例维护当前主题与可用主题列表，JS 中的 `ThemeData` 负责定义主题色板与 token 解析。控件利用 `ThemeManager.revision` 作为轻量级变更标记，只在修订号变化时重新构建状态颜色表，再通过属性绑定在悬停、按压等状态间切换，避免在窗口拖动等几何变动时反复执行 JS 查找。
-- **多语言一键切换**：`I18nManager` 单例提供当前语言与翻译函数，所有控件通过访问该单例实现文本的动态刷新。`I18nData.js` 内置英文与简体中文示例，可扩展至更多语言；组件绑定 `I18nManager.revision` 来更新缓存的翻译字符串，从而在语言切换时即时刷新，又不会在其他交互阶段造成额外的 JS 计算开销。
+- **多语言一键切换**：`I18nManager` 单例提供当前语言与翻译函数，所有控件通过访问该单例实现文本的动态刷新。`I18nData.js` 暴露 `registerTranslations()` 供每个控件或业务模块按需注册自己的词条，并内置英文与简体中文示例；组件绑定 `I18nManager.revision` 来更新缓存的翻译字符串，从而在语言切换时即时刷新，又不会在其他交互阶段造成额外的 JS 计算开销。
 - **QML/JS 对应结构**：每个控件都拆分为 QML 与 JS 两部分，QML 负责声明式界面，JS 专注样式计算与状态逻辑，方便后续复用或替换。
-- **轻量级加载动画**：自研的 `LoadingSpinner` 使用 `Canvas` 绘制并通过定时器节流更新帧率，避免系统 `BusyIndicator` 在窗口拖动或缩放时引起的卡顿，可在任何需要加载态的控件中复用。
+- **轻量级加载动画**：自研的 `LoadingSpinner` 基于 `QtQuick.Shapes` 绘制圆弧并通过旋转/透明度动画驱动，相比默认 `BusyIndicator` 或自绘 `Canvas` 方案更节省 CPU/GPU，拖动与缩放窗口时依旧保持流畅，可在任何需要加载态的控件中复用。
 - **示例应用**：`examples/gallery/main.qml` 演示了如何在 `ApplicationWindow` 中引入控件库并通过按钮切换主题与语言。
 
 ## 使用方法
@@ -69,7 +69,7 @@ YunPan/
 
 4. **扩展语言**
 
-   - 在 `I18nData.js` 中增加新的语言键值对。
+   - 调用 `I18nData.registerTranslations("langCode", { ... })` 注册控件或业务模块的词条；每个控件的 JS 逻辑文件都可以在加载时自动注册自己的翻译，从而避免集中维护庞大的字典。
    - 调用 `I18nManager.setLanguage("langCode")` 即可切换到目标语言。
 
 5. **新增控件**

--- a/README.md
+++ b/README.md
@@ -53,14 +53,14 @@ YunPan/
 
 2. **使用 Python 启动示例窗口**
 
-   如果更习惯以 Python 方式运行，可安装 [PySide6](https://doc.qt.io/qtforpython/) 或 [PyQt6](https://riverbankcomputing.com/software/pyqt/intro) 并使用仓库中提供的脚本：
+   如果更习惯以 Python 方式运行，可安装 [PySide6](https://doc.qt.io/qtforpython/)、[PyQt6](https://riverbankcomputing.com/software/pyqt/intro)、[PySide2](https://wiki.qt.io/Qt_for_Python/GettingStarted) 或 [PyQt5](https://riverbankcomputing.com/software/pyqt/intro) 并使用仓库中提供的脚本：
 
    ```bash
-   pip install PySide6  # 或者：pip install PyQt6
+   pip install PySide6  # 也可以安装 PyQt6 / PySide2 / PyQt5
    python examples/gallery/run.py
    ```
 
-   脚本会自动将仓库根目录下的 `qml/` 加入 QML 导入路径，然后载入 `examples/gallery/main.qml` 展示控件库；如果上述库均未安装，则会提示安装命令或改用 `qmlscene` 运行。
+   脚本会自动将仓库根目录下的 `qml/` 加入 QML 导入路径，然后载入 `examples/gallery/main.qml` 展示控件库；如果上述库均未安装，则会提示安装命令或改用 `qmlscene` 运行，并在加载失败时输出详细的 QML 警告信息，便于排查问题。
 
 3. **扩展主题**
 

--- a/README.md
+++ b/README.md
@@ -13,6 +13,9 @@ YunPan/
 │       │   ├── Buttons/
 │       │   │   ├── PrimaryButton.qml
 │       │   │   └── PrimaryButtonLogic.js
+│       │   ├── Indicators/
+│       │   │   ├── LoadingSpinner.qml
+│       │   │   └── LoadingSpinnerLogic.js
 │       │   └── Labels/
 │       │       ├── TitleLabel.qml
 │       │       └── TitleLabelLogic.js
@@ -32,6 +35,7 @@ YunPan/
 - **主题一键切换**：`ThemeManager` 单例维护当前主题与可用主题列表，JS 中的 `ThemeData` 负责定义主题色板与 token 解析。控件利用 `ThemeManager.revision` 作为轻量级变更标记，只在修订号变化时重新构建状态颜色表，再通过属性绑定在悬停、按压等状态间切换，避免在窗口拖动等几何变动时反复执行 JS 查找。
 - **多语言一键切换**：`I18nManager` 单例提供当前语言与翻译函数，所有控件通过访问该单例实现文本的动态刷新。`I18nData.js` 内置英文与简体中文示例，可扩展至更多语言；组件绑定 `I18nManager.revision` 来更新缓存的翻译字符串，从而在语言切换时即时刷新，又不会在其他交互阶段造成额外的 JS 计算开销。
 - **QML/JS 对应结构**：每个控件都拆分为 QML 与 JS 两部分，QML 负责声明式界面，JS 专注样式计算与状态逻辑，方便后续复用或替换。
+- **轻量级加载动画**：自研的 `LoadingSpinner` 使用 `Canvas` 绘制并通过定时器节流更新帧率，避免系统 `BusyIndicator` 在窗口拖动或缩放时引起的卡顿，可在任何需要加载态的控件中复用。
 - **示例应用**：`examples/gallery/main.qml` 演示了如何在 `ApplicationWindow` 中引入控件库并通过按钮切换主题与语言。
 
 ## 使用方法

--- a/README.md
+++ b/README.md
@@ -1,1 +1,71 @@
-# YunPan
+# 自定义 QML 控件库框架
+
+该仓库提供了一个可扩展的自定义 QML 控件库框架，用于在 Qt Quick 项目中快速搭建带有主题与多语言能力的组件体系。框架强调 **QML 与 JS 对应** 的结构，每个控件都配套一个负责业务逻辑或样式计算的 JS 文件，便于在不破坏 UI 声明的情况下复用逻辑。
+
+## 目录结构
+
+```
+YunPan/
+├── qml/
+│   └── CustomControls/
+│       ├── qmldir                     # QML 模块导出定义
+│       ├── Controls/                  # 具体控件实现
+│       │   ├── Buttons/
+│       │   │   ├── PrimaryButton.qml
+│       │   │   └── PrimaryButtonLogic.js
+│       │   └── Labels/
+│       │       ├── TitleLabel.qml
+│       │       └── TitleLabelLogic.js
+│       ├── Theme/                     # 主题管理与主题数据
+│       │   ├── ThemeManager.qml
+│       │   └── ThemeData.js
+│       └── I18n/                      # 多语言管理与语言资源
+│           ├── I18nManager.qml
+│           └── I18nData.js
+└── examples/
+    └── gallery/
+        └── main.qml                   # 控件库示例与主题/语言切换演示
+```
+
+## 功能特性
+
+- **主题一键切换**：`ThemeManager` 单例维护当前主题与可用主题列表，JS 中的 `ThemeData` 负责定义主题色板与 token 解析。控件只需通过 `ThemeManager.palette` 或 `ThemeManager.token()` 获取颜色，即可自动响应主题切换。
+- **多语言一键切换**：`I18nManager` 单例提供当前语言与翻译函数，所有控件通过访问该单例实现文本的动态刷新。`I18nData.js` 内置英文与简体中文示例，可扩展至更多语言。
+- **QML/JS 对应结构**：每个控件都拆分为 QML 与 JS 两部分，QML 负责声明式界面，JS 专注样式计算与状态逻辑，方便后续复用或替换。
+- **示例应用**：`examples/gallery/main.qml` 演示了如何在 `ApplicationWindow` 中引入控件库并通过按钮切换主题与语言。
+
+## 使用方法
+
+1. **配置 QML 模块搜索路径**
+
+   在运行示例或集成至现有项目时，需要将 `qml` 目录加入 `QML2_IMPORT_PATH`，例如：
+
+   ```bash
+   export QML2_IMPORT_PATH="$(pwd)/qml"
+   qmlscene examples/gallery/main.qml
+   ```
+
+   或者在 CMake / qmake 工程中将 `qml/` 添加到 `QML_IMPORT_PATH`。
+
+2. **扩展主题**
+
+   - 在 `ThemeData.js` 中新增主题条目并补充色板。
+   - 通过 `ThemeManager.availableThemes()` 获取主题名称列表，并利用 `ThemeManager.setTheme("yourTheme")` 切换。
+
+3. **扩展语言**
+
+   - 在 `I18nData.js` 中增加新的语言键值对。
+   - 调用 `I18nManager.setLanguage("langCode")` 即可切换到目标语言。
+
+4. **新增控件**
+
+   - 在 `Controls` 目录中创建对应的 QML 文件与 JS 文件，遵循现有命名方式（例如 `XxxControl.qml` 与 `XxxControlLogic.js`）。
+   - 在 `qmldir` 文件中注册新的控件类，便于外部通过 `import CustomControls 1.0 as Custom` 引入。
+
+## 后续建议
+
+- 若需要打包为 Qt 插件，可继续扩展 `qmldir`，或通过 C++ 插件注册类型。
+- 可结合 `Qt.labs.settings` 将用户选择的主题/语言持久化。
+- 进一步完善 CI 或单元测试（例如使用 `qmltestrunner`）。
+
+欢迎在此框架基础上继续扩展更多复杂控件与业务逻辑。

--- a/README.md
+++ b/README.md
@@ -47,17 +47,28 @@ YunPan/
 
    或者在 CMake / qmake 工程中将 `qml/` 添加到 `QML_IMPORT_PATH`。
 
-2. **扩展主题**
+2. **使用 Python 启动示例窗口**
+
+   如果更习惯以 Python 方式运行，可安装 [PySide6](https://doc.qt.io/qtforpython/) 并使用仓库中提供的脚本：
+
+   ```bash
+   pip install PySide6
+   python examples/gallery/run.py
+   ```
+
+   脚本会自动将仓库根目录下的 `qml/` 加入 QML 导入路径，然后载入 `examples/gallery/main.qml` 展示控件库。
+
+3. **扩展主题**
 
    - 在 `ThemeData.js` 中新增主题条目并补充色板。
    - 通过 `ThemeManager.availableThemes()` 获取主题名称列表，并利用 `ThemeManager.setTheme("yourTheme")` 切换。
 
-3. **扩展语言**
+4. **扩展语言**
 
    - 在 `I18nData.js` 中增加新的语言键值对。
    - 调用 `I18nManager.setLanguage("langCode")` 即可切换到目标语言。
 
-4. **新增控件**
+5. **新增控件**
 
    - 在 `Controls` 目录中创建对应的 QML 文件与 JS 文件，遵循现有命名方式（例如 `XxxControl.qml` 与 `XxxControlLogic.js`）。
    - 在 `qmldir` 文件中注册新的控件类，便于外部通过 `import CustomControls 1.0 as Custom` 引入。

--- a/README.md
+++ b/README.md
@@ -29,8 +29,8 @@ YunPan/
 
 ## 功能特性
 
-- **主题一键切换**：`ThemeManager` 单例维护当前主题与可用主题列表，JS 中的 `ThemeData` 负责定义主题色板与 token 解析。控件通常在内部缓存主题色值，并监听 `ThemeManager.themeChanged`（或直接观察 `ThemeManager.palette`）来刷新自身的颜色，从而避免在窗口拖动等频繁几何变动时重复执行 JS 逻辑。
-- **多语言一键切换**：`I18nManager` 单例提供当前语言与翻译函数，所有控件通过访问该单例实现文本的动态刷新。`I18nData.js` 内置英文与简体中文示例，可扩展至更多语言；组件可监听 `I18nManager.languageChanged` 并按需更新缓存的翻译字符串，减少界面重计算带来的卡顿。
+- **主题一键切换**：`ThemeManager` 单例维护当前主题与可用主题列表，JS 中的 `ThemeData` 负责定义主题色板与 token 解析。控件利用 `ThemeManager.revision` 作为轻量级变更标记，只在修订号变化时重新构建状态颜色表，再通过属性绑定在悬停、按压等状态间切换，避免在窗口拖动等几何变动时反复执行 JS 查找。
+- **多语言一键切换**：`I18nManager` 单例提供当前语言与翻译函数，所有控件通过访问该单例实现文本的动态刷新。`I18nData.js` 内置英文与简体中文示例，可扩展至更多语言；组件绑定 `I18nManager.revision` 来更新缓存的翻译字符串，从而在语言切换时即时刷新，又不会在其他交互阶段造成额外的 JS 计算开销。
 - **QML/JS 对应结构**：每个控件都拆分为 QML 与 JS 两部分，QML 负责声明式界面，JS 专注样式计算与状态逻辑，方便后续复用或替换。
 - **示例应用**：`examples/gallery/main.qml` 演示了如何在 `ApplicationWindow` 中引入控件库并通过按钮切换主题与语言。
 

--- a/README.md
+++ b/README.md
@@ -53,14 +53,14 @@ YunPan/
 
 2. **使用 Python 启动示例窗口**
 
-   如果更习惯以 Python 方式运行，可安装 [PySide6](https://doc.qt.io/qtforpython/) 并使用仓库中提供的脚本：
+   如果更习惯以 Python 方式运行，可安装 [PySide6](https://doc.qt.io/qtforpython/) 或 [PyQt6](https://riverbankcomputing.com/software/pyqt/intro) 并使用仓库中提供的脚本：
 
    ```bash
-   pip install PySide6
+   pip install PySide6  # 或者：pip install PyQt6
    python examples/gallery/run.py
    ```
 
-   脚本会自动将仓库根目录下的 `qml/` 加入 QML 导入路径，然后载入 `examples/gallery/main.qml` 展示控件库。
+   脚本会自动将仓库根目录下的 `qml/` 加入 QML 导入路径，然后载入 `examples/gallery/main.qml` 展示控件库；如果上述库均未安装，则会提示安装命令或改用 `qmlscene` 运行。
 
 3. **扩展主题**
 

--- a/README.md
+++ b/README.md
@@ -29,8 +29,8 @@ YunPan/
 
 ## 功能特性
 
-- **主题一键切换**：`ThemeManager` 单例维护当前主题与可用主题列表，JS 中的 `ThemeData` 负责定义主题色板与 token 解析。控件只需通过 `ThemeManager.palette` 或 `ThemeManager.token()` 获取颜色，即可自动响应主题切换，同时可监听 `ThemeManager.revision` 作为轻量的绑定依赖。
-- **多语言一键切换**：`I18nManager` 单例提供当前语言与翻译函数，所有控件通过访问该单例实现文本的动态刷新。`I18nData.js` 内置英文与简体中文示例，可扩展至更多语言；在 QML 中可绑定 `I18nManager.revision` 以便在语言切换时刷新 UI。
+- **主题一键切换**：`ThemeManager` 单例维护当前主题与可用主题列表，JS 中的 `ThemeData` 负责定义主题色板与 token 解析。控件通常在内部缓存主题色值，并监听 `ThemeManager.themeChanged`（或直接观察 `ThemeManager.palette`）来刷新自身的颜色，从而避免在窗口拖动等频繁几何变动时重复执行 JS 逻辑。
+- **多语言一键切换**：`I18nManager` 单例提供当前语言与翻译函数，所有控件通过访问该单例实现文本的动态刷新。`I18nData.js` 内置英文与简体中文示例，可扩展至更多语言；组件可监听 `I18nManager.languageChanged` 并按需更新缓存的翻译字符串，减少界面重计算带来的卡顿。
 - **QML/JS 对应结构**：每个控件都拆分为 QML 与 JS 两部分，QML 负责声明式界面，JS 专注样式计算与状态逻辑，方便后续复用或替换。
 - **示例应用**：`examples/gallery/main.qml` 演示了如何在 `ApplicationWindow` 中引入控件库并通过按钮切换主题与语言。
 
@@ -70,7 +70,7 @@ YunPan/
 
 5. **新增控件**
 
-   - 在 `Controls` 目录中创建对应的 QML 文件与 JS 文件，遵循现有命名方式（例如 `XxxControl.qml` 与 `XxxControlLogic.js`）。
+   - 在 `Controls` 目录中创建对应的 QML 文件与 JS 文件，遵循现有命名方式（例如 `XxxControl.qml` 与 `XxxControlLogic.js`）。控件内部建议缓存翻译与主题色值，并在语言/主题切换信号触发时刷新，以提升交互时的流畅度。
    - 在 `qmldir` 文件中注册新的控件类，便于外部通过 `import CustomControls 1.0 as Custom` 引入。
 
 ## 后续建议

--- a/README.md
+++ b/README.md
@@ -29,8 +29,8 @@ YunPan/
 
 ## 功能特性
 
-- **主题一键切换**：`ThemeManager` 单例维护当前主题与可用主题列表，JS 中的 `ThemeData` 负责定义主题色板与 token 解析。控件只需通过 `ThemeManager.palette` 或 `ThemeManager.token()` 获取颜色，即可自动响应主题切换。
-- **多语言一键切换**：`I18nManager` 单例提供当前语言与翻译函数，所有控件通过访问该单例实现文本的动态刷新。`I18nData.js` 内置英文与简体中文示例，可扩展至更多语言。
+- **主题一键切换**：`ThemeManager` 单例维护当前主题与可用主题列表，JS 中的 `ThemeData` 负责定义主题色板与 token 解析。控件只需通过 `ThemeManager.palette` 或 `ThemeManager.token()` 获取颜色，即可自动响应主题切换，同时可监听 `ThemeManager.revision` 作为轻量的绑定依赖。
+- **多语言一键切换**：`I18nManager` 单例提供当前语言与翻译函数，所有控件通过访问该单例实现文本的动态刷新。`I18nData.js` 内置英文与简体中文示例，可扩展至更多语言；在 QML 中可绑定 `I18nManager.revision` 以便在语言切换时刷新 UI。
 - **QML/JS 对应结构**：每个控件都拆分为 QML 与 JS 两部分，QML 负责声明式界面，JS 专注样式计算与状态逻辑，方便后续复用或替换。
 - **示例应用**：`examples/gallery/main.qml` 演示了如何在 `ApplicationWindow` 中引入控件库并通过按钮切换主题与语言。
 

--- a/README.md
+++ b/README.md
@@ -53,14 +53,14 @@ YunPan/
 
 2. **使用 Python 启动示例窗口**
 
-   如果更习惯以 Python 方式运行，可安装 [PySide6](https://doc.qt.io/qtforpython/)、[PyQt6](https://riverbankcomputing.com/software/pyqt/intro)、[PySide2](https://wiki.qt.io/Qt_for_Python/GettingStarted) 或 [PyQt5](https://riverbankcomputing.com/software/pyqt/intro) 并使用仓库中提供的脚本：
+   如果更习惯以 Python 方式运行，可安装 [PySide6](https://doc.qt.io/qtforpython/) 并使用仓库中提供的脚本：
 
    ```bash
-   pip install PySide6  # 也可以安装 PyQt6 / PySide2 / PyQt5
+   pip install PySide6
    python examples/gallery/run.py
    ```
 
-   脚本会自动将仓库根目录下的 `qml/` 加入 QML 导入路径，然后载入 `examples/gallery/main.qml` 展示控件库；如果上述库均未安装，则会提示安装命令或改用 `qmlscene` 运行，并在加载失败时输出详细的 QML 警告信息，便于排查问题。
+   脚本会自动将仓库根目录下的 `qml/` 加入 QML 导入路径，然后载入 `examples/gallery/main.qml` 展示控件库；若未安装 PySide6，则会提示安装命令或改用 `qmlscene` 运行，并在加载失败时输出详细的 QML 警告信息，便于排查问题。
 
 3. **扩展主题**
 

--- a/examples/gallery/Translations.js
+++ b/examples/gallery/Translations.js
@@ -1,0 +1,16 @@
+.pragma library
+.import "../../qml/CustomControls/I18n/I18nData.js" as I18nData
+
+I18nData.registerTranslations("en", {
+    actions: {
+        toggleTheme: "Toggle theme",
+        toggleLanguage: "Switch language"
+    }
+});
+
+I18nData.registerTranslations("zh_CN", {
+    actions: {
+        toggleTheme: "切换主题",
+        toggleLanguage: "切换语言"
+    }
+});

--- a/examples/gallery/main.qml
+++ b/examples/gallery/main.qml
@@ -9,15 +9,39 @@ ApplicationWindow {
     width: 480
     height: 320
 
-    title: {
-        Custom.I18nManager.revision;
-        return Custom.I18nManager.tr("labels.headline", "Custom Controls Library");
+    property string windowTitle: Custom.I18nManager.tr("labels.headline", "Custom Controls Library")
+    property color windowBackground: Custom.ThemeManager.token("surface.background")
+    property color panelBackground: Custom.ThemeManager.token("surface.backgroundRaised")
+    property color panelBorder: Custom.ThemeManager.token("surface.border")
+
+    function updateTitle() {
+        windowTitle = Custom.I18nManager.tr("labels.headline", "Custom Controls Library");
     }
 
-    color: {
-        Custom.ThemeManager.revision;
-        return Custom.ThemeManager.token("surface.background");
+    function updateThemeColors() {
+        windowBackground = Custom.ThemeManager.token("surface.background");
+        panelBackground = Custom.ThemeManager.token("surface.backgroundRaised");
+        panelBorder = Custom.ThemeManager.token("surface.border");
     }
+
+    Component.onCompleted: {
+        updateTitle();
+        updateThemeColors();
+    }
+
+    Connections {
+        target: Custom.I18nManager
+        onLanguageChanged: updateTitle()
+    }
+
+    Connections {
+        target: Custom.ThemeManager
+        onThemeChanged: updateThemeColors()
+    }
+
+    title: windowTitle
+
+    color: windowBackground
 
     ColumnLayout {
         anchors.fill: parent
@@ -33,18 +57,40 @@ ApplicationWindow {
             spacing: 12
 
             Button {
-                text: {
-                    Custom.I18nManager.revision;
-                    return Custom.I18nManager.tr("actions.toggleTheme", "Toggle theme");
+                id: toggleThemeButton
+                property string cachedText: Custom.I18nManager.tr("actions.toggleTheme", "Toggle theme")
+
+                function updateText() {
+                    cachedText = Custom.I18nManager.tr("actions.toggleTheme", "Toggle theme");
                 }
+
+                Component.onCompleted: updateText()
+
+                Connections {
+                    target: Custom.I18nManager
+                    onLanguageChanged: updateText()
+                }
+
+                text: cachedText
                 onClicked: Custom.ThemeManager.toggleTheme()
             }
 
             Button {
-                text: {
-                    Custom.I18nManager.revision;
-                    return Custom.I18nManager.tr("actions.toggleLanguage", "Switch language");
+                id: toggleLanguageButton
+                property string cachedText: Custom.I18nManager.tr("actions.toggleLanguage", "Switch language")
+
+                function updateText() {
+                    cachedText = Custom.I18nManager.tr("actions.toggleLanguage", "Switch language");
                 }
+
+                Component.onCompleted: updateText()
+
+                Connections {
+                    target: Custom.I18nManager
+                    onLanguageChanged: updateText()
+                }
+
+                text: cachedText
                 onClicked: Custom.I18nManager.toggleLanguage()
             }
         }
@@ -53,14 +99,8 @@ ApplicationWindow {
             Layout.fillWidth: true
             Layout.fillHeight: true
             radius: 12
-            color: {
-                Custom.ThemeManager.revision;
-                return Custom.ThemeManager.token("surface.backgroundRaised");
-            }
-            border.color: {
-                Custom.ThemeManager.revision;
-                return Custom.ThemeManager.token("surface.border");
-            }
+            color: window.panelBackground
+            border.color: window.panelBorder
 
             Column {
                 anchors.centerIn: parent

--- a/examples/gallery/main.qml
+++ b/examples/gallery/main.qml
@@ -2,6 +2,7 @@ import QtQuick 2.15
 import QtQuick.Controls 2.15
 import QtQuick.Layouts 1.15
 import CustomControls 1.0 as Custom
+import "Translations.js" as GalleryStrings
 
 ApplicationWindow {
     id: window
@@ -9,6 +10,7 @@ ApplicationWindow {
     width: 480
     height: 320
 
+    readonly property bool _stringsLoaded: GalleryStrings !== undefined
     property int languageRevision: Custom.I18nManager.revision
     property int themeRevision: Custom.ThemeManager.revision
     property string windowTitle: {
@@ -81,6 +83,7 @@ ApplicationWindow {
 
                 Custom.PrimaryButton {
                     textKey: "buttons.secondary.default"
+                    busyTextKey: "buttons.secondary.loading"
                     busy: true
                 }
             }

--- a/examples/gallery/main.qml
+++ b/examples/gallery/main.qml
@@ -9,34 +9,23 @@ ApplicationWindow {
     width: 480
     height: 320
 
-    property string windowTitle: Custom.I18nManager.tr("labels.headline", "Custom Controls Library")
-    property color windowBackground: Custom.ThemeManager.token("surface.background")
-    property color panelBackground: Custom.ThemeManager.token("surface.backgroundRaised")
-    property color panelBorder: Custom.ThemeManager.token("surface.border")
-
-    function updateTitle() {
-        windowTitle = Custom.I18nManager.tr("labels.headline", "Custom Controls Library");
+    property int languageRevision: Custom.I18nManager.revision
+    property int themeRevision: Custom.ThemeManager.revision
+    property string windowTitle: {
+        languageRevision;
+        return Custom.I18nManager.tr("labels.headline", "Custom Controls Library");
     }
-
-    function updateThemeColors() {
-        windowBackground = Custom.ThemeManager.token("surface.background");
-        panelBackground = Custom.ThemeManager.token("surface.backgroundRaised");
-        panelBorder = Custom.ThemeManager.token("surface.border");
+    property color windowBackground: {
+        themeRevision;
+        return Custom.ThemeManager.token("surface.background");
     }
-
-    Component.onCompleted: {
-        updateTitle();
-        updateThemeColors();
+    property color panelBackground: {
+        themeRevision;
+        return Custom.ThemeManager.token("surface.backgroundRaised");
     }
-
-    Connections {
-        target: Custom.I18nManager
-        onLanguageChanged: updateTitle()
-    }
-
-    Connections {
-        target: Custom.ThemeManager
-        onThemeChanged: updateThemeColors()
+    property color panelBorder: {
+        themeRevision;
+        return Custom.ThemeManager.token("surface.border");
     }
 
     title: windowTitle
@@ -58,39 +47,19 @@ ApplicationWindow {
 
             Button {
                 id: toggleThemeButton
-                property string cachedText: Custom.I18nManager.tr("actions.toggleTheme", "Toggle theme")
-
-                function updateText() {
-                    cachedText = Custom.I18nManager.tr("actions.toggleTheme", "Toggle theme");
+                text: {
+                    window.languageRevision;
+                    return Custom.I18nManager.tr("actions.toggleTheme", "Toggle theme");
                 }
-
-                Component.onCompleted: updateText()
-
-                Connections {
-                    target: Custom.I18nManager
-                    onLanguageChanged: updateText()
-                }
-
-                text: cachedText
                 onClicked: Custom.ThemeManager.toggleTheme()
             }
 
             Button {
                 id: toggleLanguageButton
-                property string cachedText: Custom.I18nManager.tr("actions.toggleLanguage", "Switch language")
-
-                function updateText() {
-                    cachedText = Custom.I18nManager.tr("actions.toggleLanguage", "Switch language");
+                text: {
+                    window.languageRevision;
+                    return Custom.I18nManager.tr("actions.toggleLanguage", "Switch language");
                 }
-
-                Component.onCompleted: updateText()
-
-                Connections {
-                    target: Custom.I18nManager
-                    onLanguageChanged: updateText()
-                }
-
-                text: cachedText
                 onClicked: Custom.I18nManager.toggleLanguage()
             }
         }

--- a/examples/gallery/main.qml
+++ b/examples/gallery/main.qml
@@ -10,12 +10,12 @@ ApplicationWindow {
     height: 320
 
     title: {
-        Custom.I18nManager.currentLanguage;
+        Custom.I18nManager.revision;
         return Custom.I18nManager.tr("labels.headline", "Custom Controls Library");
     }
 
     color: {
-        Custom.ThemeManager.palette;
+        Custom.ThemeManager.revision;
         return Custom.ThemeManager.token("surface.background");
     }
 
@@ -34,7 +34,7 @@ ApplicationWindow {
 
             Button {
                 text: {
-                    Custom.I18nManager.currentLanguage;
+                    Custom.I18nManager.revision;
                     return Custom.I18nManager.tr("actions.toggleTheme", "Toggle theme");
                 }
                 onClicked: Custom.ThemeManager.toggleTheme()
@@ -42,7 +42,7 @@ ApplicationWindow {
 
             Button {
                 text: {
-                    Custom.I18nManager.currentLanguage;
+                    Custom.I18nManager.revision;
                     return Custom.I18nManager.tr("actions.toggleLanguage", "Switch language");
                 }
                 onClicked: Custom.I18nManager.toggleLanguage()
@@ -54,11 +54,11 @@ ApplicationWindow {
             Layout.fillHeight: true
             radius: 12
             color: {
-                Custom.ThemeManager.palette;
+                Custom.ThemeManager.revision;
                 return Custom.ThemeManager.token("surface.backgroundRaised");
             }
             border.color: {
-                Custom.ThemeManager.palette;
+                Custom.ThemeManager.revision;
                 return Custom.ThemeManager.token("surface.border");
             }
 

--- a/examples/gallery/main.qml
+++ b/examples/gallery/main.qml
@@ -1,0 +1,80 @@
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+import QtQuick.Layouts 1.15
+import CustomControls 1.0 as Custom
+
+ApplicationWindow {
+    id: window
+    visible: true
+    width: 480
+    height: 320
+
+    title: {
+        Custom.I18nManager.currentLanguage;
+        return Custom.I18nManager.tr("labels.headline", "Custom Controls Library");
+    }
+
+    color: {
+        Custom.ThemeManager.palette;
+        return Custom.ThemeManager.token("surface.background");
+    }
+
+    ColumnLayout {
+        anchors.fill: parent
+        anchors.margins: 24
+        spacing: 16
+
+        Custom.TitleLabel {
+            Layout.fillWidth: true
+            horizontalAlignment: Text.AlignLeft
+        }
+
+        RowLayout {
+            spacing: 12
+
+            Button {
+                text: {
+                    Custom.I18nManager.currentLanguage;
+                    return Custom.I18nManager.tr("actions.toggleTheme", "Toggle theme");
+                }
+                onClicked: Custom.ThemeManager.toggleTheme()
+            }
+
+            Button {
+                text: {
+                    Custom.I18nManager.currentLanguage;
+                    return Custom.I18nManager.tr("actions.toggleLanguage", "Switch language");
+                }
+                onClicked: Custom.I18nManager.toggleLanguage()
+            }
+        }
+
+        Rectangle {
+            Layout.fillWidth: true
+            Layout.fillHeight: true
+            radius: 12
+            color: {
+                Custom.ThemeManager.palette;
+                return Custom.ThemeManager.token("surface.backgroundRaised");
+            }
+            border.color: {
+                Custom.ThemeManager.palette;
+                return Custom.ThemeManager.token("surface.border");
+            }
+
+            Column {
+                anchors.centerIn: parent
+                spacing: 12
+
+                Custom.PrimaryButton {
+                    textKey: "buttons.primary.default"
+                }
+
+                Custom.PrimaryButton {
+                    textKey: "buttons.secondary.default"
+                    busy: true
+                }
+            }
+        }
+    }
+}

--- a/examples/gallery/run.py
+++ b/examples/gallery/run.py
@@ -1,15 +1,41 @@
-"""Run the gallery QML demo with PySide6."""
+"""Run the gallery QML demo with a Qt for Python binding."""
 
 from __future__ import annotations
 
 import sys
 from pathlib import Path
+from typing import Tuple
 
-from PySide6.QtGui import QGuiApplication
-from PySide6.QtQml import QQmlApplicationEngine
+QT_BINDING = ""
+
+try:  # Prefer PySide6 because it matches Qt's official Python binding.
+    from PySide6.QtCore import QUrl
+    from PySide6.QtGui import QGuiApplication
+    from PySide6.QtQml import QQmlApplicationEngine
+
+    QT_BINDING = "PySide6"
+except ImportError as pyside_error:  # pragma: no cover - informative fallback path
+    try:
+        from PyQt6.QtCore import QUrl
+        from PyQt6.QtGui import QGuiApplication
+        from PyQt6.QtQml import QQmlApplicationEngine
+
+        QT_BINDING = "PyQt6"
+    except ImportError as pyqt_error:  # pragma: no cover - informative fallback path
+        missing = ["PySide6", "PyQt6"]
+        message = (
+            "Unable to import any Qt for Python binding.\n"
+            "Install one of the following packages and re-run the script:\n"
+            f"  pip install {missing[0]}\n"
+            f"  pip install {missing[1]}\n"
+            "Alternatively run the example with qmlscene after exporting QML2_IMPORT_PATH.\n"
+            f"PySide6 import error: {pyside_error}\n"
+            f"PyQt6 import error: {pyqt_error}"
+        )
+        raise SystemExit(message) from pyqt_error
 
 
-def _resolve_paths() -> tuple[Path, Path]:
+def _resolve_paths() -> Tuple[Path, Path]:
     """Return the gallery directory and qml import path."""
     gallery_dir = Path(__file__).resolve().parent
     repo_root = gallery_dir.parents[1]
@@ -26,7 +52,7 @@ def main() -> int:
     engine.addImportPath(str(qml_dir))
 
     qml_file = gallery_dir / "main.qml"
-    engine.load(str(qml_file))
+    engine.load(QUrl.fromLocalFile(str(qml_file)))
 
     if not engine.rootObjects():
         return -1

--- a/examples/gallery/run.py
+++ b/examples/gallery/run.py
@@ -1,0 +1,38 @@
+"""Run the gallery QML demo with PySide6."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+from PySide6.QtGui import QGuiApplication
+from PySide6.QtQml import QQmlApplicationEngine
+
+
+def _resolve_paths() -> tuple[Path, Path]:
+    """Return the gallery directory and qml import path."""
+    gallery_dir = Path(__file__).resolve().parent
+    repo_root = gallery_dir.parents[1]
+    qml_dir = repo_root / "qml"
+    return gallery_dir, qml_dir
+
+
+def main() -> int:
+    """Launch the QML gallery example."""
+    gallery_dir, qml_dir = _resolve_paths()
+
+    app = QGuiApplication(sys.argv)
+    engine = QQmlApplicationEngine()
+    engine.addImportPath(str(qml_dir))
+
+    qml_file = gallery_dir / "main.qml"
+    engine.load(str(qml_file))
+
+    if not engine.rootObjects():
+        return -1
+
+    return app.exec()
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/examples/gallery/run.py
+++ b/examples/gallery/run.py
@@ -1,4 +1,4 @@
-"""Run the gallery QML demo with a Qt for Python binding."""
+"""Run the gallery QML demo with PySide6."""
 
 from __future__ import annotations
 
@@ -6,65 +6,24 @@ import sys
 from pathlib import Path
 from typing import Callable, Tuple
 
-QT_BINDING = ""
-
 
 def _load_binding():
-    """Import a Qt for Python binding and expose a unified API surface."""
+    """Import PySide6 and expose a unified API surface."""
 
-    errors = {}
-
-    def _record(name: str, error: Exception) -> None:
-        errors[name] = error
-
-    # Try modern Qt 6 bindings first.
-    try:  # Prefer PySide6 because it matches Qt's official Python binding.
+    try:
         from PySide6.QtCore import QUrl  # type: ignore
         from PySide6.QtGui import QGuiApplication  # type: ignore
         from PySide6.QtQml import QQmlApplicationEngine  # type: ignore
 
-        return "PySide6", QUrl, QGuiApplication, QQmlApplicationEngine
+        return QUrl, QGuiApplication, QQmlApplicationEngine
     except ImportError as error:  # pragma: no cover - informative fallback path
-        _record("PySide6", error)
-
-    try:
-        from PyQt6.QtCore import QUrl  # type: ignore
-        from PyQt6.QtGui import QGuiApplication  # type: ignore
-        from PyQt6.QtQml import QQmlApplicationEngine  # type: ignore
-
-        return "PyQt6", QUrl, QGuiApplication, QQmlApplicationEngine
-    except ImportError as error:  # pragma: no cover - informative fallback path
-        _record("PyQt6", error)
-
-    # Fall back to widely installed Qt 5 bindings so the script can run on
-    # systems that have not migrated to Qt 6 yet.
-    try:
-        from PySide2.QtCore import QUrl  # type: ignore
-        from PySide2.QtGui import QGuiApplication  # type: ignore
-        from PySide2.QtQml import QQmlApplicationEngine  # type: ignore
-
-        return "PySide2", QUrl, QGuiApplication, QQmlApplicationEngine
-    except ImportError as error:  # pragma: no cover - informative fallback path
-        _record("PySide2", error)
-
-    try:
-        from PyQt5.QtCore import QUrl  # type: ignore
-        from PyQt5.QtGui import QGuiApplication  # type: ignore
-        from PyQt5.QtQml import QQmlApplicationEngine  # type: ignore
-
-        return "PyQt5", QUrl, QGuiApplication, QQmlApplicationEngine
-    except ImportError as error:  # pragma: no cover - informative fallback path
-        _record("PyQt5", error)
-
-    missing = ["PySide6", "PyQt6", "PySide2", "PyQt5"]
-    message = (
-        "Unable to import any Qt for Python binding.\n"
-        "Install one of the following packages and re-run the script:\n"
-        + "\n".join(f"  pip install {name}" for name in missing)
-        + "\nAlternatively run the example with qmlscene after exporting QML2_IMPORT_PATH.\n"
-        + "\n".join(f"{name} import error: {errors.get(name)}" for name in missing)
-    )
-    raise SystemExit(message)
+        message = (
+            "Unable to import PySide6.\n"
+            "Please install the package and re-run the script:\n"
+            "  pip install PySide6\n"
+            f"Import error: {error}"
+        )
+        raise SystemExit(message)
 
 
 def _resolve_paths() -> Tuple[Path, Path]:
@@ -79,33 +38,18 @@ def main() -> int:
     """Launch the QML gallery example."""
     gallery_dir, qml_dir = _resolve_paths()
 
-    global QT_BINDING
-    QT_BINDING, QUrl, QGuiApplication, QQmlApplicationEngine = _load_binding()
+    QUrl, QGuiApplication, QQmlApplicationEngine = _load_binding()
 
     app = QGuiApplication(sys.argv)
     engine = QQmlApplicationEngine()
     engine.addImportPath(str(qml_dir))
 
-    collected_warnings = []
-    warnings_attr = getattr(engine, "warnings", None)
-    if warnings_attr is not None and hasattr(warnings_attr, "connect"):
-        # PyQt exposes QQmlApplicationEngine.warnings as a signal rather than a
-        # callable, so capture anything emitted while the engine loads.
-        def _collect_warnings(errors):
-            collected_warnings.extend(errors)
-
-        warnings_attr.connect(_collect_warnings)
-
     qml_file = gallery_dir / "main.qml"
     engine.load(QUrl.fromLocalFile(str(qml_file)))
 
     if not engine.rootObjects():
-        warnings_list = collected_warnings
-        if not warnings_list and callable(warnings_attr):
-            try:
-                warnings_list = list(warnings_attr())
-            except TypeError:
-                warnings_list = []
+        warnings_attr = getattr(engine, "warnings", None)
+        warnings_list = warnings_attr() if callable(warnings_attr) else []
 
         for warning in warnings_list:
             print(warning.toString())

--- a/qml/CustomControls/Controls/Buttons/PrimaryButton.qml
+++ b/qml/CustomControls/Controls/Buttons/PrimaryButton.qml
@@ -1,0 +1,65 @@
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+import "." as Custom
+import "PrimaryButtonLogic.js" as Logic
+
+Button {
+    id: control
+
+    property string textKey: "buttons.primary.default"
+    property bool busy: false
+
+    readonly property var themePalette: Custom.ThemeManager.palette
+
+    implicitHeight: contentItem.implicitHeight + topPadding + bottomPadding
+    implicitWidth: Math.max(background.implicitWidth, contentItem.implicitWidth + leftPadding + rightPadding)
+
+    leftPadding: Logic.horizontalPadding()
+    rightPadding: Logic.horizontalPadding()
+    topPadding: Logic.verticalPadding()
+    bottomPadding: Logic.verticalPadding()
+
+    enabled: !control.busy
+    focusPolicy: Qt.StrongFocus
+    opacity: Logic.opacity(control)
+
+    contentItem: Row {
+        id: layout
+        spacing: control.busy ? 8 : 0
+        anchors.centerIn: parent
+
+        BusyIndicator {
+            visible: control.busy
+            running: control.busy
+            implicitWidth: 16
+            implicitHeight: 16
+        }
+
+        Text {
+            function translatedText() {
+                return Custom.I18nManager.tr(control.busy ? "buttons.primary.loading" : control.textKey,
+                                              control.busy ? "Loading..." : control.textKey);
+            }
+
+            text: {
+                Custom.I18nManager.currentLanguage;
+                return translatedText();
+            }
+
+            font.bold: true
+            color: Logic.foregroundColor(control.themePalette, control)
+            horizontalAlignment: Text.AlignHCenter
+            verticalAlignment: Text.AlignVCenter
+            wrapMode: Text.NoWrap
+        }
+    }
+
+    background: Rectangle {
+        id: background
+        implicitWidth: 120
+        implicitHeight: 36
+        radius: 6
+        color: Logic.backgroundColor(control.themePalette, control)
+        border.color: "transparent"
+    }
+}

--- a/qml/CustomControls/Controls/Buttons/PrimaryButton.qml
+++ b/qml/CustomControls/Controls/Buttons/PrimaryButton.qml
@@ -40,9 +40,10 @@ Button {
         spacing: control.busy ? 8 : 0
         anchors.centerIn: parent
 
-        BusyIndicator {
+        Custom.LoadingSpinner {
             visible: control.busy
             running: control.busy
+            color: control.foregroundColor
             implicitWidth: 16
             implicitHeight: 16
         }

--- a/qml/CustomControls/Controls/Buttons/PrimaryButton.qml
+++ b/qml/CustomControls/Controls/Buttons/PrimaryButton.qml
@@ -43,17 +43,18 @@ Button {
     contentItem: Row {
         id: layout
         anchors.centerIn: parent
-        spacing: busySpinner.visible ? 8 : 0
+        spacing: spinnerLoader.active && spinnerLoader.item ? 8 : 0
 
-        Custom.LoadingSpinner {
-            id: busySpinner
-            visible: control.busy
-            running: control.busy
-            color: control.foregroundColor
-            implicitWidth: 16
-            implicitHeight: 16
-            width: visible ? implicitWidth : 0
-            height: visible ? implicitHeight : 0
+        Loader {
+            id: spinnerLoader
+            active: control.busy
+            sourceComponent: Component {
+                Custom.LoadingSpinner {
+                    color: control.foregroundColor
+                    implicitWidth: 16
+                    implicitHeight: 16
+                }
+            }
         }
 
         Text {

--- a/qml/CustomControls/Controls/Buttons/PrimaryButton.qml
+++ b/qml/CustomControls/Controls/Buttons/PrimaryButton.qml
@@ -9,7 +9,56 @@ Button {
     property string textKey: "buttons.primary.default"
     property bool busy: false
 
-    readonly property var themePalette: Custom.ThemeManager.palette
+    property var themePalette: Custom.ThemeManager.palette
+    property string displayText: Custom.I18nManager.tr(control.textKey, control.textKey)
+    property color backgroundColor: "#000000"
+    property color foregroundColor: "#ffffff"
+    property real resolvedOpacity: 1.0
+
+    function updateDisplayText() {
+        displayText = Custom.I18nManager.tr(control.busy ? "buttons.primary.loading" : control.textKey,
+                                            control.busy ? "Loading..." : control.textKey);
+    }
+
+    function updateColors() {
+        backgroundColor = Logic.backgroundColor(control.themePalette, control);
+        foregroundColor = Logic.foregroundColor(control.themePalette, control);
+    }
+
+    function updateOpacity() {
+        resolvedOpacity = Logic.opacity(control);
+    }
+
+    function refreshVisualState() {
+        updateColors();
+        updateOpacity();
+    }
+
+    Component.onCompleted: {
+        updateDisplayText();
+        refreshVisualState();
+    }
+
+    onBusyChanged: {
+        updateDisplayText();
+        refreshVisualState();
+    }
+
+    onTextKeyChanged: updateDisplayText()
+    onHoveredChanged: updateColors()
+    onDownChanged: updateColors()
+    onEnabledChanged: updateOpacity()
+    onThemePaletteChanged: updateColors()
+
+    Connections {
+        target: Custom.I18nManager
+        onLanguageChanged: updateDisplayText()
+    }
+
+    Connections {
+        target: Custom.ThemeManager
+        onThemeChanged: updateColors()
+    }
 
     implicitHeight: contentItem.implicitHeight + topPadding + bottomPadding
     implicitWidth: Math.max(background.implicitWidth, contentItem.implicitWidth + leftPadding + rightPadding)
@@ -18,10 +67,10 @@ Button {
     rightPadding: Logic.horizontalPadding()
     topPadding: Logic.verticalPadding()
     bottomPadding: Logic.verticalPadding()
-
+    
     enabled: !control.busy
     focusPolicy: Qt.StrongFocus
-    opacity: Logic.opacity(control)
+    opacity: control.resolvedOpacity
 
     contentItem: Row {
         id: layout
@@ -36,18 +85,10 @@ Button {
         }
 
         Text {
-            function translatedText() {
-                return Custom.I18nManager.tr(control.busy ? "buttons.primary.loading" : control.textKey,
-                                              control.busy ? "Loading..." : control.textKey);
-            }
-
-            text: {
-                Custom.I18nManager.revision;
-                return translatedText();
-            }
+            text: control.displayText
 
             font.bold: true
-            color: Logic.foregroundColor(control.themePalette, control)
+            color: control.foregroundColor
             horizontalAlignment: Text.AlignHCenter
             verticalAlignment: Text.AlignVCenter
             wrapMode: Text.NoWrap
@@ -59,7 +100,7 @@ Button {
         implicitWidth: 120
         implicitHeight: 36
         radius: 6
-        color: Logic.backgroundColor(control.themePalette, control)
+        color: control.backgroundColor
         border.color: "transparent"
     }
 }

--- a/qml/CustomControls/Controls/Buttons/PrimaryButton.qml
+++ b/qml/CustomControls/Controls/Buttons/PrimaryButton.qml
@@ -42,15 +42,19 @@ Button {
 
     contentItem: Row {
         id: layout
-        spacing: control.busy ? 8 : 0
         anchors.centerIn: parent
+        spacing: spinnerLoader.active && spinnerLoader.item ? 8 : 0
 
-        Custom.LoadingSpinner {
-            visible: control.busy
-            running: control.busy
-            color: control.foregroundColor
-            implicitWidth: 16
-            implicitHeight: 16
+        Loader {
+            id: spinnerLoader
+            active: control.busy
+            sourceComponent: Component {
+                Custom.LoadingSpinner {
+                    color: control.foregroundColor
+                    implicitWidth: 16
+                    implicitHeight: 16
+                }
+            }
         }
 
         Text {

--- a/qml/CustomControls/Controls/Buttons/PrimaryButton.qml
+++ b/qml/CustomControls/Controls/Buttons/PrimaryButton.qml
@@ -7,7 +7,10 @@ Button {
     id: control
 
     property string textKey: "buttons.primary.default"
+    property string textFallback: Logic.defaultTextFallback(control.textKey)
     property bool busy: false
+    property string busyTextKey: Logic.defaultBusyKey()
+    property string busyTextFallback: Logic.busyFallback()
 
     property int languageRevision: Custom.I18nManager.revision
     property int themeRevision: Custom.ThemeManager.revision
@@ -17,7 +20,9 @@ Button {
         return Logic.colorSet(themePalette);
     }
     property string displayText: Logic.displayText(Custom.I18nManager, languageRevision,
-                                                  control.textKey, control.busy)
+                                                  control.textKey, control.textFallback,
+                                                  control.busy, control.busyTextKey,
+                                                  control.busyTextFallback)
     property color backgroundColor: Logic.backgroundColor(colorRoles, control.hovered,
                                                           control.down, control.enabled)
     property color foregroundColor: Logic.foregroundColor(colorRoles, control.enabled)

--- a/qml/CustomControls/Controls/Buttons/PrimaryButton.qml
+++ b/qml/CustomControls/Controls/Buttons/PrimaryButton.qml
@@ -42,7 +42,7 @@ Button {
             }
 
             text: {
-                Custom.I18nManager.currentLanguage;
+                Custom.I18nManager.revision;
                 return translatedText();
             }
 

--- a/qml/CustomControls/Controls/Buttons/PrimaryButton.qml
+++ b/qml/CustomControls/Controls/Buttons/PrimaryButton.qml
@@ -1,6 +1,6 @@
 import QtQuick 2.15
 import QtQuick.Controls 2.15
-import "." as Custom
+import "../.." as Custom
 import "PrimaryButtonLogic.js" as Logic
 
 Button {
@@ -9,56 +9,19 @@ Button {
     property string textKey: "buttons.primary.default"
     property bool busy: false
 
+    property int languageRevision: Custom.I18nManager.revision
+    property int themeRevision: Custom.ThemeManager.revision
     property var themePalette: Custom.ThemeManager.palette
-    property string displayText: Custom.I18nManager.tr(control.textKey, control.textKey)
-    property color backgroundColor: "#000000"
-    property color foregroundColor: "#ffffff"
-    property real resolvedOpacity: 1.0
-
-    function updateDisplayText() {
-        displayText = Custom.I18nManager.tr(control.busy ? "buttons.primary.loading" : control.textKey,
-                                            control.busy ? "Loading..." : control.textKey);
+    property var colorRoles: {
+        themeRevision;
+        return Logic.colorSet(themePalette);
     }
-
-    function updateColors() {
-        backgroundColor = Logic.backgroundColor(control.themePalette, control);
-        foregroundColor = Logic.foregroundColor(control.themePalette, control);
-    }
-
-    function updateOpacity() {
-        resolvedOpacity = Logic.opacity(control);
-    }
-
-    function refreshVisualState() {
-        updateColors();
-        updateOpacity();
-    }
-
-    Component.onCompleted: {
-        updateDisplayText();
-        refreshVisualState();
-    }
-
-    onBusyChanged: {
-        updateDisplayText();
-        refreshVisualState();
-    }
-
-    onTextKeyChanged: updateDisplayText()
-    onHoveredChanged: updateColors()
-    onDownChanged: updateColors()
-    onEnabledChanged: updateOpacity()
-    onThemePaletteChanged: updateColors()
-
-    Connections {
-        target: Custom.I18nManager
-        onLanguageChanged: updateDisplayText()
-    }
-
-    Connections {
-        target: Custom.ThemeManager
-        onThemeChanged: updateColors()
-    }
+    property string displayText: Logic.displayText(Custom.I18nManager, languageRevision,
+                                                  control.textKey, control.busy)
+    property color backgroundColor: Logic.backgroundColor(colorRoles, control.hovered,
+                                                          control.down, control.enabled)
+    property color foregroundColor: Logic.foregroundColor(colorRoles, control.enabled)
+    property real resolvedOpacity: Logic.opacity(control.enabled)
 
     implicitHeight: contentItem.implicitHeight + topPadding + bottomPadding
     implicitWidth: Math.max(background.implicitWidth, contentItem.implicitWidth + leftPadding + rightPadding)
@@ -67,7 +30,7 @@ Button {
     rightPadding: Logic.horizontalPadding()
     topPadding: Logic.verticalPadding()
     bottomPadding: Logic.verticalPadding()
-    
+
     enabled: !control.busy
     focusPolicy: Qt.StrongFocus
     opacity: control.resolvedOpacity

--- a/qml/CustomControls/Controls/Buttons/PrimaryButton.qml
+++ b/qml/CustomControls/Controls/Buttons/PrimaryButton.qml
@@ -43,18 +43,17 @@ Button {
     contentItem: Row {
         id: layout
         anchors.centerIn: parent
-        spacing: spinnerLoader.active && spinnerLoader.item ? 8 : 0
+        spacing: busySpinner.visible ? 8 : 0
 
-        Loader {
-            id: spinnerLoader
-            active: control.busy
-            sourceComponent: Component {
-                Custom.LoadingSpinner {
-                    color: control.foregroundColor
-                    implicitWidth: 16
-                    implicitHeight: 16
-                }
-            }
+        Custom.LoadingSpinner {
+            id: busySpinner
+            visible: control.busy
+            running: control.busy
+            color: control.foregroundColor
+            implicitWidth: 16
+            implicitHeight: 16
+            width: visible ? implicitWidth : 0
+            height: visible ? implicitHeight : 0
         }
 
         Text {

--- a/qml/CustomControls/Controls/Buttons/PrimaryButtonLogic.js
+++ b/qml/CustomControls/Controls/Buttons/PrimaryButtonLogic.js
@@ -1,0 +1,30 @@
+.pragma library
+
+function backgroundColor(palette, control) {
+    if (!palette || !palette.primary)
+        return "#000000";
+
+    if (!control.enabled)
+        return palette.surface.border;
+    if (control.down)
+        return palette.primary.backgroundHovered;
+    if (control.hovered)
+        return palette.primary.backgroundHovered;
+    return palette.primary.background;
+}
+
+function foregroundColor(palette, control) {
+    if (!palette || !palette.primary)
+        return "#ffffff";
+
+    if (!control.enabled)
+        return palette.surface.subtle;
+    return palette.primary.foreground;
+}
+
+function opacity(control) {
+    return control.enabled ? 1.0 : 0.7;
+}
+
+function horizontalPadding() { return 20; }
+function verticalPadding() { return 10; }

--- a/qml/CustomControls/Controls/Buttons/PrimaryButtonLogic.js
+++ b/qml/CustomControls/Controls/Buttons/PrimaryButtonLogic.js
@@ -1,29 +1,54 @@
 .pragma library
 
-function backgroundColor(palette, control) {
-    if (!palette || !palette.primary)
+function colorSet(palette) {
+    var surface = palette && palette.surface ? palette.surface : {};
+    var primary = palette && palette.primary ? palette.primary : {};
+
+    return {
+        background: primary.background || "#000000",
+        hoveredBackground: primary.backgroundHovered || primary.background || "#000000",
+        pressedBackground: primary.backgroundHovered || primary.background || "#000000",
+        disabledBackground: surface.border || "#444444",
+        foreground: primary.foreground || "#ffffff",
+        disabledForeground: surface.subtle || "#ffffff"
+    };
+}
+
+function backgroundColor(colors, hovered, down, enabled) {
+    if (!colors)
         return "#000000";
 
-    if (!control.enabled)
-        return palette.surface.border;
-    if (control.down)
-        return palette.primary.backgroundHovered;
-    if (control.hovered)
-        return palette.primary.backgroundHovered;
-    return palette.primary.background;
+    if (!enabled)
+        return colors.disabledBackground;
+    if (down)
+        return colors.pressedBackground;
+    if (hovered)
+        return colors.hoveredBackground;
+    return colors.background;
 }
 
-function foregroundColor(palette, control) {
-    if (!palette || !palette.primary)
+function foregroundColor(colors, enabled) {
+    if (!colors)
         return "#ffffff";
 
-    if (!control.enabled)
-        return palette.surface.subtle;
-    return palette.primary.foreground;
+    return enabled ? colors.foreground : colors.disabledForeground;
 }
 
-function opacity(control) {
-    return control.enabled ? 1.0 : 0.7;
+function opacity(enabled) {
+    return enabled ? 1.0 : 0.7;
+}
+
+function displayText(i18nManager, revision, textKey, busy) {
+    var fallback = busy ? "Loading..." : textKey;
+
+    if (!i18nManager)
+        return fallback;
+
+    void revision;
+
+    return busy
+            ? i18nManager.tr("buttons.primary.loading", fallback)
+            : i18nManager.tr(textKey, fallback);
 }
 
 function horizontalPadding() { return 20; }

--- a/qml/CustomControls/Controls/Buttons/PrimaryButtonLogic.js
+++ b/qml/CustomControls/Controls/Buttons/PrimaryButtonLogic.js
@@ -1,4 +1,31 @@
 .pragma library
+.import "../../I18n/I18nData.js" as I18nData
+
+I18nData.registerTranslations("en", {
+    buttons: {
+        primary: {
+            default: "Confirm",
+            loading: "Loading..."
+        },
+        secondary: {
+            default: "Cancel",
+            loading: "Working..."
+        }
+    }
+});
+
+I18nData.registerTranslations("zh_CN", {
+    buttons: {
+        primary: {
+            default: "确认",
+            loading: "加载中..."
+        },
+        secondary: {
+            default: "取消",
+            loading: "处理中..."
+        }
+    }
+});
 
 function colorSet(palette) {
     var surface = palette && palette.surface ? palette.surface : {};
@@ -38,17 +65,30 @@ function opacity(enabled) {
     return enabled ? 1.0 : 0.7;
 }
 
-function displayText(i18nManager, revision, textKey, busy) {
-    var fallback = busy ? "Loading..." : textKey;
+function defaultBusyKey() {
+    return "buttons.primary.loading";
+}
+
+function busyFallback() {
+    return I18nData.translate(I18nData.defaultLanguage(), defaultBusyKey(), "Loading...");
+}
+
+function defaultTextFallback(key) {
+    return I18nData.translate(I18nData.defaultLanguage(), key, key);
+}
+
+function displayText(i18nManager, revision, textKey, textFallback, busy, busyKey, busyFallbackText) {
+    var fallback = busy
+            ? (busyFallbackText || busyKey || textFallback || textKey)
+            : (textFallback || textKey);
 
     if (!i18nManager)
         return fallback;
 
     void revision;
 
-    return busy
-            ? i18nManager.tr("buttons.primary.loading", fallback)
-            : i18nManager.tr(textKey, fallback);
+    var lookupKey = busy && busyKey ? busyKey : textKey;
+    return i18nManager.tr(lookupKey, fallback);
 }
 
 function horizontalPadding() { return 20; }

--- a/qml/CustomControls/Controls/Indicators/LoadingSpinner.qml
+++ b/qml/CustomControls/Controls/Indicators/LoadingSpinner.qml
@@ -23,6 +23,9 @@ Item {
     width: implicitWidth
     height: implicitHeight
     transformOrigin: Item.Center
+    layer.enabled: true
+    layer.smooth: true
+    layer.mipmap: true
 
     function scheduleRepaint() {
         if (arcCanvas.available)
@@ -64,10 +67,9 @@ Item {
         }
     }
 
-    NumberAnimation {
+    RotationAnimator {
         id: spinAnimation
         target: spinner
-        property: "rotation"
         from: 0
         to: 360
         duration: spinner.rotationDuration
@@ -80,16 +82,14 @@ Item {
         loops: Animation.Infinite
         running: false
 
-        NumberAnimation {
+        OpacityAnimator {
             target: arcCanvas
-            property: "opacity"
             to: spinner.minOpacity
             duration: spinner.pulseDuration / 2
             easing.type: Easing.InOutQuad
         }
-        NumberAnimation {
+        OpacityAnimator {
             target: arcCanvas
-            property: "opacity"
             to: 1.0
             duration: spinner.pulseDuration / 2
             easing.type: Easing.InOutQuad
@@ -109,6 +109,7 @@ Item {
     onRunningChanged: updateAnimations()
     onVisibleChanged: updateAnimations()
     onWindowChanged: updateAnimations()
+    onActiveFocusChanged: updateAnimations()
 
     Component.onCompleted: {
         scheduleRepaint();

--- a/qml/CustomControls/Controls/Indicators/LoadingSpinner.qml
+++ b/qml/CustomControls/Controls/Indicators/LoadingSpinner.qml
@@ -1,0 +1,80 @@
+import QtQuick 2.15
+import "LoadingSpinnerLogic.js" as Logic
+
+Item {
+    id: spinner
+
+    property bool running: true
+    property color color: "#ffffff"
+    property real minOpacity: Logic.minOpacity()
+    property real strokeRatio: Logic.strokeRatio()
+    property real sweepRatio: Logic.sweepRatio()
+    property int segmentCount: Logic.segmentCount()
+    property int stepInterval: Logic.stepInterval()
+
+    property int _phase: 0
+
+    implicitWidth: Logic.defaultDiameter()
+    implicitHeight: Logic.defaultDiameter()
+    width: implicitWidth
+    height: implicitHeight
+
+    Canvas {
+        id: canvas
+        anchors.fill: parent
+        renderTarget: Canvas.FramebufferObject
+
+        onPaint: {
+            var count = spinner.segmentCount > 0 ? spinner.segmentCount : 1;
+            var ctx = getContext("2d");
+            Logic.paint(ctx, width, height, spinner.color, count, spinner._phase,
+                        spinner.minOpacity, spinner.strokeRatio, spinner.sweepRatio);
+        }
+    }
+
+    Timer {
+        id: ticker
+        interval: spinner.stepInterval
+        repeat: true
+        running: false
+
+        onTriggered: {
+            var count = spinner.segmentCount > 0 ? spinner.segmentCount : 1;
+            spinner._phase = Logic.nextPhase(spinner._phase, count);
+            canvas.requestPaint();
+        }
+    }
+
+    function updateTicker() {
+        ticker.running = spinner.running && spinner.visible && spinner.window !== null;
+    }
+
+    onRunningChanged: updateTicker()
+    onVisibleChanged: {
+        updateTicker();
+        if (spinner.visible)
+            canvas.requestPaint();
+    }
+    onWindowChanged: updateTicker()
+
+    onWidthChanged: canvas.requestPaint()
+    onHeightChanged: canvas.requestPaint()
+    onColorChanged: canvas.requestPaint()
+    onMinOpacityChanged: canvas.requestPaint()
+    onStrokeRatioChanged: canvas.requestPaint()
+    onSweepRatioChanged: canvas.requestPaint()
+    onSegmentCountChanged: {
+        if (spinner.segmentCount <= 0) {
+            spinner._phase = 0;
+        } else if (spinner._phase >= spinner.segmentCount) {
+            spinner._phase = spinner._phase % spinner.segmentCount;
+        }
+        canvas.requestPaint();
+        updateTicker();
+    }
+
+    Component.onCompleted: {
+        canvas.requestPaint();
+        updateTicker();
+    }
+}

--- a/qml/CustomControls/Controls/Indicators/LoadingSpinner.qml
+++ b/qml/CustomControls/Controls/Indicators/LoadingSpinner.qml
@@ -29,7 +29,6 @@ Item {
         id: arcShape
         anchors.fill: parent
         antialiasing: true
-        preferredRendererType: Shape.CurveRenderer
         opacity: 1.0
 
         ShapePath {

--- a/qml/CustomControls/Controls/Indicators/LoadingSpinner.qml
+++ b/qml/CustomControls/Controls/Indicators/LoadingSpinner.qml
@@ -24,7 +24,9 @@ Item {
 
     width: implicitWidth
     height: implicitHeight
-    transformOrigin: Item.Center
+    layer.enabled: true
+    layer.smooth: true
+    layer.mipmap: false
 
     Canvas {
         id: arcCanvas
@@ -33,6 +35,12 @@ Item {
         smooth: true
         renderTarget: Canvas.Image
         opacity: 1.0
+        transform: Rotation {
+            id: spinTransform
+            origin.x: width / 2
+            origin.y: height / 2
+            angle: spinner._baseRotation
+        }
 
         onPaint: {
             var ctx = getContext("2d");
@@ -55,10 +63,9 @@ Item {
         }
     }
 
-    NumberAnimation {
+    RotationAnimator {
         id: spinAnimation
-        target: spinner
-        property: "rotation"
+        target: spinTransform
         from: spinner._baseRotation
         to: spinner._baseRotation + 360
         duration: spinner.rotationDuration
@@ -71,16 +78,14 @@ Item {
         loops: Animation.Infinite
         running: false
 
-        NumberAnimation {
+        OpacityAnimator {
             target: arcCanvas
-            property: "opacity"
             to: spinner.minOpacity
             duration: spinner.pulseDuration / 2
             easing.type: Easing.InOutQuad
         }
-        NumberAnimation {
+        OpacityAnimator {
             target: arcCanvas
-            property: "opacity"
             to: 1.0
             duration: spinner.pulseDuration / 2
             easing.type: Easing.InOutQuad
@@ -93,12 +98,12 @@ Item {
 
     function updateAnimations() {
         var shouldRun = spinner._active;
+        if (shouldRun && !spinAnimation.running)
+            spinTransform.angle = spinner._baseRotation;
         spinAnimation.running = shouldRun;
         pulseAnimation.running = shouldRun;
-        if (shouldRun && spinner.rotation !== spinner._baseRotation)
-            spinner.rotation = spinner._baseRotation;
         if (!shouldRun) {
-            spinner.rotation = spinner._baseRotation;
+            spinTransform.angle = spinner._baseRotation;
             arcCanvas.opacity = 1.0;
         }
     }
@@ -113,7 +118,7 @@ Item {
     onStrokeRatioChanged: requestRedraw()
 
     Component.onCompleted: {
-        spinner.rotation = spinner._baseRotation;
+        spinTransform.angle = spinner._baseRotation;
         requestRedraw();
         updateAnimations();
     }

--- a/qml/CustomControls/Controls/Indicators/LoadingSpinnerLogic.js
+++ b/qml/CustomControls/Controls/Indicators/LoadingSpinnerLogic.js
@@ -1,7 +1,5 @@
 .pragma library
 
-var TWO_PI = Math.PI * 2;
-
 function defaultDiameter() {
     return 16;
 }
@@ -10,68 +8,22 @@ function strokeRatio() {
     return 0.18;
 }
 
-function sweepRatio() {
-    return 0.65;
+function sweepAngle() {
+    return 220;
 }
 
-function segmentCount() {
-    return 12;
+function rotationDuration() {
+    return 900;
 }
 
-function stepInterval() {
-    return 90;
+function pulseDuration() {
+    return 1200;
 }
 
 function minOpacity() {
-    return 0.25;
+    return 0.35;
 }
 
-function nextPhase(current, count) {
-    if (count <= 0)
-        return 0;
-    return (current + 1) % count;
-}
-
-function opacityFor(offset, baseOpacity) {
-    var falloff = 0.65;
-    var clampedBase = Math.max(0.0, Math.min(baseOpacity, 1.0));
-    return clampedBase + (1.0 - clampedBase) * Math.pow(falloff, offset);
-}
-
-function paint(ctx, width, height, color, count, phase, baseOpacity, strokeRatio, sweepRatio) {
-    if (!ctx)
-        return;
-
-    ctx.resetTransform();
-    ctx.clearRect(0, 0, width, height);
-
-    var size = Math.min(width, height);
-    if (size <= 0 || count <= 0)
-        return;
-
-    var stroke = Math.max(1, Math.round(size * strokeRatio));
-    var radius = Math.max(0, (size - stroke) / 2);
-    var stepAngle = TWO_PI / count;
-    var sweep = stepAngle * sweepRatio;
-
-    ctx.save();
-    ctx.translate(width / 2, height / 2);
-    ctx.lineWidth = stroke;
-    ctx.lineCap = "round";
-    ctx.strokeStyle = color;
-
-    for (var i = 0; i < count; ++i) {
-        var offset = i - phase;
-        while (offset < 0)
-            offset += count;
-
-        ctx.globalAlpha = opacityFor(offset, baseOpacity);
-        ctx.beginPath();
-        var startAngle = i * stepAngle;
-        ctx.arc(0, 0, radius, startAngle, startAngle + sweep, false);
-        ctx.stroke();
-    }
-
-    ctx.restore();
-    ctx.globalAlpha = 1.0;
+function strokeWidthFor(size, ratio) {
+    return Math.max(1, Math.round(size * ratio));
 }

--- a/qml/CustomControls/Controls/Indicators/LoadingSpinnerLogic.js
+++ b/qml/CustomControls/Controls/Indicators/LoadingSpinnerLogic.js
@@ -1,0 +1,77 @@
+.pragma library
+
+var TWO_PI = Math.PI * 2;
+
+function defaultDiameter() {
+    return 16;
+}
+
+function strokeRatio() {
+    return 0.18;
+}
+
+function sweepRatio() {
+    return 0.65;
+}
+
+function segmentCount() {
+    return 12;
+}
+
+function stepInterval() {
+    return 90;
+}
+
+function minOpacity() {
+    return 0.25;
+}
+
+function nextPhase(current, count) {
+    if (count <= 0)
+        return 0;
+    return (current + 1) % count;
+}
+
+function opacityFor(offset, baseOpacity) {
+    var falloff = 0.65;
+    var clampedBase = Math.max(0.0, Math.min(baseOpacity, 1.0));
+    return clampedBase + (1.0 - clampedBase) * Math.pow(falloff, offset);
+}
+
+function paint(ctx, width, height, color, count, phase, baseOpacity, strokeRatio, sweepRatio) {
+    if (!ctx)
+        return;
+
+    ctx.resetTransform();
+    ctx.clearRect(0, 0, width, height);
+
+    var size = Math.min(width, height);
+    if (size <= 0 || count <= 0)
+        return;
+
+    var stroke = Math.max(1, Math.round(size * strokeRatio));
+    var radius = Math.max(0, (size - stroke) / 2);
+    var stepAngle = TWO_PI / count;
+    var sweep = stepAngle * sweepRatio;
+
+    ctx.save();
+    ctx.translate(width / 2, height / 2);
+    ctx.lineWidth = stroke;
+    ctx.lineCap = "round";
+    ctx.strokeStyle = color;
+
+    for (var i = 0; i < count; ++i) {
+        var offset = i - phase;
+        while (offset < 0)
+            offset += count;
+
+        ctx.globalAlpha = opacityFor(offset, baseOpacity);
+        ctx.beginPath();
+        var startAngle = i * stepAngle;
+        ctx.arc(0, 0, radius, startAngle, startAngle + sweep, false);
+        ctx.stroke();
+    }
+
+    ctx.restore();
+    ctx.globalAlpha = 1.0;
+}

--- a/qml/CustomControls/Controls/Labels/TitleLabel.qml
+++ b/qml/CustomControls/Controls/Labels/TitleLabel.qml
@@ -10,7 +10,7 @@ Text {
     readonly property var themePalette: Custom.ThemeManager.palette
 
     text: {
-        Custom.I18nManager.currentLanguage;
+        Custom.I18nManager.revision;
         return Custom.I18nManager.tr(control.textKey, control.textKey);
     }
 

--- a/qml/CustomControls/Controls/Labels/TitleLabel.qml
+++ b/qml/CustomControls/Controls/Labels/TitleLabel.qml
@@ -1,39 +1,21 @@
 import QtQuick 2.15
-import "." as Custom
+import "../.." as Custom
 import "TitleLabelLogic.js" as Logic
 
 Text {
     id: control
 
     property string textKey: "labels.headline"
+    property int languageRevision: Custom.I18nManager.revision
+    property int themeRevision: Custom.ThemeManager.revision
     property var themePalette: Custom.ThemeManager.palette
-    property string displayText: Custom.I18nManager.tr(control.textKey, control.textKey)
-    property color displayColor: Logic.color(themePalette)
-
-    function updateText() {
-        displayText = Custom.I18nManager.tr(control.textKey, control.textKey);
+    property string displayText: {
+        languageRevision;
+        return Custom.I18nManager.tr(control.textKey, control.textKey);
     }
-
-    function updateColor() {
-        displayColor = Logic.color(themePalette);
-    }
-
-    Component.onCompleted: {
-        updateText();
-        updateColor();
-    }
-
-    onTextKeyChanged: updateText()
-    onThemePaletteChanged: updateColor()
-
-    Connections {
-        target: Custom.I18nManager
-        onLanguageChanged: updateText()
-    }
-
-    Connections {
-        target: Custom.ThemeManager
-        onThemeChanged: updateColor()
+    property color displayColor: {
+        themeRevision;
+        return Logic.color(themePalette);
     }
 
     text: displayText

--- a/qml/CustomControls/Controls/Labels/TitleLabel.qml
+++ b/qml/CustomControls/Controls/Labels/TitleLabel.qml
@@ -6,15 +6,39 @@ Text {
     id: control
 
     property string textKey: "labels.headline"
+    property var themePalette: Custom.ThemeManager.palette
+    property string displayText: Custom.I18nManager.tr(control.textKey, control.textKey)
+    property color displayColor: Logic.color(themePalette)
 
-    readonly property var themePalette: Custom.ThemeManager.palette
-
-    text: {
-        Custom.I18nManager.revision;
-        return Custom.I18nManager.tr(control.textKey, control.textKey);
+    function updateText() {
+        displayText = Custom.I18nManager.tr(control.textKey, control.textKey);
     }
 
-    color: Logic.color(themePalette)
+    function updateColor() {
+        displayColor = Logic.color(themePalette);
+    }
+
+    Component.onCompleted: {
+        updateText();
+        updateColor();
+    }
+
+    onTextKeyChanged: updateText()
+    onThemePaletteChanged: updateColor()
+
+    Connections {
+        target: Custom.I18nManager
+        onLanguageChanged: updateText()
+    }
+
+    Connections {
+        target: Custom.ThemeManager
+        onThemeChanged: updateColor()
+    }
+
+    text: displayText
+
+    color: displayColor
     font.pixelSize: Logic.fontSize()
     font.weight: Logic.fontWeight()
     wrapMode: Text.WrapAnywhere

--- a/qml/CustomControls/Controls/Labels/TitleLabel.qml
+++ b/qml/CustomControls/Controls/Labels/TitleLabel.qml
@@ -1,0 +1,22 @@
+import QtQuick 2.15
+import "." as Custom
+import "TitleLabelLogic.js" as Logic
+
+Text {
+    id: control
+
+    property string textKey: "labels.headline"
+
+    readonly property var themePalette: Custom.ThemeManager.palette
+
+    text: {
+        Custom.I18nManager.currentLanguage;
+        return Custom.I18nManager.tr(control.textKey, control.textKey);
+    }
+
+    color: Logic.color(themePalette)
+    font.pixelSize: Logic.fontSize()
+    font.weight: Logic.fontWeight()
+    wrapMode: Text.WrapAnywhere
+    horizontalAlignment: Text.AlignHCenter
+}

--- a/qml/CustomControls/Controls/Labels/TitleLabel.qml
+++ b/qml/CustomControls/Controls/Labels/TitleLabel.qml
@@ -11,7 +11,7 @@ Text {
     property var themePalette: Custom.ThemeManager.palette
     property string displayText: {
         languageRevision;
-        return Custom.I18nManager.tr(control.textKey, control.textKey);
+        return Custom.I18nManager.tr(control.textKey, Logic.defaultText(control.textKey));
     }
     property color displayColor: {
         themeRevision;

--- a/qml/CustomControls/Controls/Labels/TitleLabelLogic.js
+++ b/qml/CustomControls/Controls/Labels/TitleLabelLogic.js
@@ -1,0 +1,15 @@
+.pragma library
+
+function fontSize() {
+    return 24;
+}
+
+function fontWeight() {
+    return 600;
+}
+
+function color(palette) {
+    if (!palette || !palette.surface)
+        return "#000000";
+    return palette.surface.foreground;
+}

--- a/qml/CustomControls/Controls/Labels/TitleLabelLogic.js
+++ b/qml/CustomControls/Controls/Labels/TitleLabelLogic.js
@@ -1,4 +1,21 @@
 .pragma library
+.import "../../I18n/I18nData.js" as I18nData
+
+I18nData.registerTranslations("en", {
+    labels: {
+        headline: "Custom Controls Library"
+    }
+});
+
+I18nData.registerTranslations("zh_CN", {
+    labels: {
+        headline: "自定义控件库"
+    }
+});
+
+function defaultText(key) {
+    return I18nData.translate(I18nData.defaultLanguage(), key, key);
+}
 
 function fontSize() {
     return 24;

--- a/qml/CustomControls/I18n/I18nData.js
+++ b/qml/CustomControls/I18n/I18nData.js
@@ -1,0 +1,71 @@
+.pragma library
+
+var translations = {
+    "en": {
+        languageName: "English",
+        buttons: {
+            primary: {
+                default: "Confirm",
+                loading: "Loading..."
+            },
+            secondary: {
+                default: "Cancel"
+            }
+        },
+        labels: {
+            headline: "Custom Controls Library"
+        },
+        actions: {
+            toggleTheme: "Toggle theme",
+            toggleLanguage: "Switch language"
+        }
+    },
+    "zh_CN": {
+        languageName: "简体中文",
+        buttons: {
+            primary: {
+                default: "确认",
+                loading: "加载中..."
+            },
+            secondary: {
+                default: "取消"
+            }
+        },
+        labels: {
+            headline: "自定义控件库"
+        },
+        actions: {
+            toggleTheme: "切换主题",
+            toggleLanguage: "切换语言"
+        }
+    }
+};
+
+function defaultLanguage() {
+    return "en";
+}
+
+function hasLanguage(code) {
+    return Object.prototype.hasOwnProperty.call(translations, code);
+}
+
+function languageCodes() {
+    return Object.keys(translations);
+}
+
+function translate(code, path, fallback) {
+    if (!hasLanguage(code))
+        return fallback !== undefined ? fallback : path;
+
+    var section = translations[code];
+    var parts = path.split(".");
+    for (var i = 0; i < parts.length; ++i) {
+        if (section === undefined || section === null)
+            break;
+        section = section[parts[i]];
+    }
+
+    if (section === undefined || section === null)
+        return fallback !== undefined ? fallback : path;
+    return section;
+}

--- a/qml/CustomControls/I18n/I18nManager.qml
+++ b/qml/CustomControls/I18n/I18nManager.qml
@@ -1,0 +1,40 @@
+pragma Singleton
+import QtQuick 2.15
+import "I18nData.js" as I18nData
+
+QtObject {
+    id: i18n
+
+    property string currentLanguage: I18nData.defaultLanguage()
+
+    signal languageChanged(string language)
+
+    function availableLanguages() {
+        return I18nData.languageCodes();
+    }
+
+    function setLanguage(language) {
+        if (!I18nData.hasLanguage(language)) {
+            console.warn("I18nManager: unknown language", language);
+            return;
+        }
+        if (language === currentLanguage)
+            return;
+
+        currentLanguage = language;
+        languageChanged(language);
+    }
+
+    function toggleLanguage() {
+        var langs = availableLanguages();
+        if (langs.length < 2)
+            return;
+        var index = langs.indexOf(currentLanguage);
+        var nextIndex = (index + 1) % langs.length;
+        setLanguage(langs[nextIndex]);
+    }
+
+    function tr(key, fallback) {
+        return I18nData.translate(currentLanguage, key, fallback);
+    }
+}

--- a/qml/CustomControls/I18n/I18nManager.qml
+++ b/qml/CustomControls/I18n/I18nManager.qml
@@ -6,6 +6,8 @@ QtObject {
     id: i18n
 
     property string currentLanguage: I18nData.defaultLanguage()
+    property int revision: 0
+    property var _translationCache: Object.create(null)
 
     signal languageChanged(string language)
 
@@ -22,7 +24,6 @@ QtObject {
             return;
 
         currentLanguage = language;
-        languageChanged(language);
     }
 
     function toggleLanguage() {
@@ -35,6 +36,19 @@ QtObject {
     }
 
     function tr(key, fallback) {
-        return I18nData.translate(currentLanguage, key, fallback);
+        var cacheKey = key + "|" + (fallback !== undefined ? fallback : "");
+        var cached = _translationCache[cacheKey];
+        if (cached !== undefined)
+            return cached;
+
+        var value = I18nData.translate(currentLanguage, key, fallback);
+        _translationCache[cacheKey] = value;
+        return value;
+    }
+
+    onCurrentLanguageChanged: {
+        _translationCache = Object.create(null);
+        revision += 1;
+        languageChanged(currentLanguage);
     }
 }

--- a/qml/CustomControls/Theme/ThemeData.js
+++ b/qml/CustomControls/Theme/ThemeData.js
@@ -1,0 +1,66 @@
+.pragma library
+
+var themes = {
+    light: {
+        name: "Light",
+        primary: {
+            background: "#2D8CF0",
+            backgroundHovered: "#5AA1F2",
+            foreground: "#ffffff"
+        },
+        surface: {
+            background: "#f7f7f7",
+            backgroundRaised: "#ffffff",
+            border: "#e0e0e0",
+            foreground: "#1f1f1f",
+            subtle: "#666666"
+        }
+    },
+    dark: {
+        name: "Dark",
+        primary: {
+            background: "#3B82F6",
+            backgroundHovered: "#60A5FA",
+            foreground: "#111827"
+        },
+        surface: {
+            background: "#161B22",
+            backgroundRaised: "#1F2933",
+            border: "#374151",
+            foreground: "#F9FAFB",
+            subtle: "#9CA3AF"
+        }
+    }
+};
+
+function defaultTheme() {
+    return "light";
+}
+
+function hasTheme(name) {
+    return Object.prototype.hasOwnProperty.call(themes, name);
+}
+
+function theme(name) {
+    if (!hasTheme(name))
+        return themes[defaultTheme()];
+    return themes[name];
+}
+
+function themeNames() {
+    return Object.keys(themes);
+}
+
+function resolveToken(theme, path) {
+    if (!path)
+        return theme;
+
+    var parts = path.split(".");
+    var value = theme;
+    for (var i = 0; i < parts.length; ++i) {
+        if (value === undefined || value === null)
+            return undefined;
+        value = value[parts[i]];
+    }
+    return value;
+}

--- a/qml/CustomControls/Theme/ThemeManager.qml
+++ b/qml/CustomControls/Theme/ThemeManager.qml
@@ -1,0 +1,42 @@
+pragma Singleton
+import QtQuick 2.15
+import "ThemeData.js" as ThemeData
+
+QtObject {
+    id: themeManager
+
+    property string currentTheme: ThemeData.defaultTheme()
+    property var palette: ThemeData.theme(currentTheme)
+
+    signal themeChanged(string themeName)
+
+    function availableThemes() {
+        return ThemeData.themeNames();
+    }
+
+    function setTheme(themeName) {
+        if (!ThemeData.hasTheme(themeName)) {
+            console.warn("ThemeManager: unknown theme", themeName);
+            return;
+        }
+        if (themeName === currentTheme)
+            return;
+
+        currentTheme = themeName;
+    }
+
+    function toggleTheme() {
+        var names = availableThemes();
+        if (names.length < 2)
+            return;
+        var index = names.indexOf(currentTheme);
+        var nextIndex = (index + 1) % names.length;
+        setTheme(names[nextIndex]);
+    }
+
+    function token(path) {
+        return ThemeData.resolveToken(palette, path);
+    }
+
+    onCurrentThemeChanged: themeChanged(currentTheme)
+}

--- a/qml/CustomControls/Theme/ThemeManager.qml
+++ b/qml/CustomControls/Theme/ThemeManager.qml
@@ -7,6 +7,8 @@ QtObject {
 
     property string currentTheme: ThemeData.defaultTheme()
     property var palette: ThemeData.theme(currentTheme)
+    property int revision: 0
+    property var _tokenCache: Object.create(null)
 
     signal themeChanged(string themeName)
 
@@ -35,8 +37,22 @@ QtObject {
     }
 
     function token(path) {
-        return ThemeData.resolveToken(palette, path);
+        if (!path)
+            return palette;
+
+        var cached = _tokenCache[path];
+        if (cached !== undefined)
+            return cached;
+
+        var value = ThemeData.resolveToken(palette, path);
+        _tokenCache[path] = value;
+        return value;
     }
 
-    onCurrentThemeChanged: themeChanged(currentTheme)
+    onPaletteChanged: _tokenCache = Object.create(null)
+    onCurrentThemeChanged: {
+        _tokenCache = Object.create(null);
+        revision += 1;
+        themeChanged(currentTheme);
+    }
 }

--- a/qml/CustomControls/qmldir
+++ b/qml/CustomControls/qmldir
@@ -3,3 +3,4 @@ singleton ThemeManager 1.0 Theme/ThemeManager.qml
 singleton I18nManager 1.0 I18n/I18nManager.qml
 PrimaryButton 1.0 Controls/Buttons/PrimaryButton.qml
 TitleLabel 1.0 Controls/Labels/TitleLabel.qml
+LoadingSpinner 1.0 Controls/Indicators/LoadingSpinner.qml

--- a/qml/CustomControls/qmldir
+++ b/qml/CustomControls/qmldir
@@ -1,0 +1,5 @@
+module CustomControls
+singleton ThemeManager 1.0 Theme/ThemeManager.qml
+singleton I18nManager 1.0 I18n/I18nManager.qml
+PrimaryButton 1.0 Controls/Buttons/PrimaryButton.qml
+TitleLabel 1.0 Controls/Labels/TitleLabel.qml


### PR DESCRIPTION
## Summary
- add a CustomControls QML module with theme and i18n singletons for runtime switching
- implement PrimaryButton and TitleLabel components with paired JS logic helpers
- document the directory structure and provide a gallery example demonstrating toggles

## Testing
- not run (Qt tooling not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68d38f0b718c8322885303c78bcde473