### PR TITLE
Remove bundled loading spinner asset

### DIFF
--- a/examples/gallery/main.qml
+++ b/examples/gallery/main.qml
@@ -83,38 +83,67 @@ ApplicationWindow {
             color: window.panelBackground
             border.color: window.panelBorder
 
+            Component {
+                id: actionsTab
+
+                Item {
+                    anchors.fill: parent
+
+                    ColumnLayout {
+                        anchors.fill: parent
+                        spacing: 12
+
+                        RowLayout {
+                            Layout.alignment: Qt.AlignHCenter
+                            spacing: 12
+
+                            Custom.PrimaryButton {
+                                Layout.alignment: Qt.AlignHCenter
+                                textKey: "buttons.primary.default"
+                            }
+
+                            Custom.PrimaryButton {
+                                Layout.alignment: Qt.AlignHCenter
+                                textKey: "buttons.secondary.default"
+                                busyTextKey: "buttons.secondary.loading"
+                                busy: true
+                            }
+                        }
+                    }
+                }
+            }
+
+            Component {
+                id: accountsTab
+
+                Item {
+                    anchors.fill: parent
+
+                    Custom.ExpandableTable {
+                        anchors.fill: parent
+                        model: accountTableModel
+                        alternatingRowColors: true
+                        columns: [
+                            { title: qsTr("Name"), role: "name", flex: 2 },
+                            { title: qsTr("Email"), role: "email", flex: 3 },
+                            { title: qsTr("Storage"), role: "storage", alignment: "right", flex: 1 },
+                            { title: qsTr("Status"), role: "status", flex: 1 }
+                        ]
+                    }
+                }
+            }
+
             ColumnLayout {
                 anchors.fill: parent
                 anchors.margins: 24
                 spacing: 16
 
-                RowLayout {
-                    Layout.alignment: Qt.AlignHCenter
-                    spacing: 12
-
-                    Custom.PrimaryButton {
-                        Layout.alignment: Qt.AlignHCenter
-                        textKey: "buttons.primary.default"
-                    }
-
-                    Custom.PrimaryButton {
-                        Layout.alignment: Qt.AlignHCenter
-                        textKey: "buttons.secondary.default"
-                        busyTextKey: "buttons.secondary.loading"
-                        busy: true
-                    }
-                }
-
-                Custom.ExpandableTable {
+                Custom.TabView {
                     Layout.fillWidth: true
                     Layout.fillHeight: true
-                    model: accountTableModel
-                    alternatingRowColors: true
-                    columns: [
-                        { title: qsTr("Name"), role: "name", flex: 2 },
-                        { title: qsTr("Email"), role: "email", flex: 3 },
-                        { title: qsTr("Storage"), role: "storage", alignment: "right", flex: 1 },
-                        { title: qsTr("Status"), role: "status", flex: 1 }
+                    tabs: [
+                        { title: qsTr("Actions"), component: actionsTab },
+                        { title: qsTr("Accounts"), component: accountsTab }
                     ]
                 }
             }

--- a/examples/gallery/main.qml
+++ b/examples/gallery/main.qml
@@ -10,6 +10,16 @@ ApplicationWindow {
     width: 480
     height: 320
 
+    ListModel {
+        id: accountTableModel
+
+        ListElement { name: "Alice"; email: "alice@example.com"; storage: "15 GB"; status: "Active" }
+        ListElement { name: "Bob"; email: "bob@example.com"; storage: "8 GB"; status: "Invited" }
+        ListElement { name: "Charlie"; email: "charlie@example.com"; storage: "24 GB"; status: "Active" }
+        ListElement { name: "Diana"; email: "diana@example.com"; storage: "4 GB"; status: "Suspended" }
+        ListElement { name: "Evelyn"; email: "evelyn@example.com"; storage: "32 GB"; status: "Active" }
+    }
+
     readonly property bool _stringsLoaded: GalleryStrings !== undefined
     property int languageRevision: Custom.I18nManager.revision
     property int themeRevision: Custom.ThemeManager.revision
@@ -73,18 +83,39 @@ ApplicationWindow {
             color: window.panelBackground
             border.color: window.panelBorder
 
-            Column {
-                anchors.centerIn: parent
-                spacing: 12
+            ColumnLayout {
+                anchors.fill: parent
+                anchors.margins: 24
+                spacing: 16
 
-                Custom.PrimaryButton {
-                    textKey: "buttons.primary.default"
+                RowLayout {
+                    Layout.alignment: Qt.AlignHCenter
+                    spacing: 12
+
+                    Custom.PrimaryButton {
+                        Layout.alignment: Qt.AlignHCenter
+                        textKey: "buttons.primary.default"
+                    }
+
+                    Custom.PrimaryButton {
+                        Layout.alignment: Qt.AlignHCenter
+                        textKey: "buttons.secondary.default"
+                        busyTextKey: "buttons.secondary.loading"
+                        busy: true
+                    }
                 }
 
-                Custom.PrimaryButton {
-                    textKey: "buttons.secondary.default"
-                    busyTextKey: "buttons.secondary.loading"
-                    busy: true
+                Custom.ExpandableTable {
+                    Layout.fillWidth: true
+                    Layout.fillHeight: true
+                    model: accountTableModel
+                    alternatingRowColors: true
+                    columns: [
+                        { title: qsTr("Name"), role: "name", flex: 2 },
+                        { title: qsTr("Email"), role: "email", flex: 3 },
+                        { title: qsTr("Storage"), role: "storage", alignment: "right", flex: 1 },
+                        { title: qsTr("Status"), role: "status", flex: 1 }
+                    ]
                 }
             }
         }

--- a/qml/CustomControls/Controls/Indicators/LoadingSpinner.qml
+++ b/qml/CustomControls/Controls/Indicators/LoadingSpinner.qml
@@ -1,5 +1,4 @@
 import QtQuick 2.15
-import QtGraphicalEffects 1.15
 import "LoadingSpinnerLogic.js" as Logic
 
 Item {
@@ -25,17 +24,10 @@ Item {
         asynchronous: false
         source: spinner.source
         fillMode: Image.PreserveAspectFit
-        playing: spinner._shouldPlay
-        cache: true
+        playing: spinner._shouldPlay && spinner.source !== ""
+        cache: false
         speed: spinner.playbackRate
-        visible: false
-    }
-
-    ColorOverlay {
-        anchors.fill: image
-        visible: image.status === Image.Ready
-        source: image
+        visible: status === Image.Ready && spinner.source !== ""
         color: spinner.color
-        cached: true
     }
 }

--- a/qml/CustomControls/Controls/Indicators/LoadingSpinnerLogic.js
+++ b/qml/CustomControls/Controls/Indicators/LoadingSpinnerLogic.js
@@ -3,27 +3,3 @@
 function defaultDiameter() {
     return 16;
 }
-
-function strokeRatio() {
-    return 0.18;
-}
-
-function sweepAngle() {
-    return 220;
-}
-
-function rotationDuration() {
-    return 900;
-}
-
-function pulseDuration() {
-    return 1200;
-}
-
-function minOpacity() {
-    return 0.35;
-}
-
-function strokeWidthFor(size, ratio) {
-    return Math.max(1, Math.round(size * ratio));
-}

--- a/qml/CustomControls/Controls/Tables/ExpandableTable.qml
+++ b/qml/CustomControls/Controls/Tables/ExpandableTable.qml
@@ -1,0 +1,228 @@
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+import QtQuick.Layouts 1.15
+import "../.." as Custom
+import "ExpandableTableLogic.js" as Logic
+
+Item {
+    id: control
+
+    property var model: null
+    property var columns: []
+    property bool expandColumnsToFill: true
+    property int rowHeight: 40
+    property int headerHeight: 44
+    property int visibleRowCountHint: 6
+    property real cellPadding: 12
+    property real columnSpacing: 12
+    property bool alternatingRowColors: true
+
+    property real leftPadding: 16
+    property real rightPadding: 16
+    property real topPadding: 16
+    property real bottomPadding: 16
+
+    property int themeRevision: Custom.ThemeManager.revision
+    property var themePalette: Custom.ThemeManager.palette
+
+    property color backgroundColor: Logic.surfaceBackground(themePalette)
+    property color headerBackgroundColor: Logic.headerBackground(themePalette)
+    property color headerForegroundColor: Logic.headerForeground(themePalette)
+    property color rowForegroundColor: Logic.rowForeground(themePalette)
+    property color gridColor: Logic.gridColor(themePalette)
+
+    readonly property int columnCount: Array.isArray(columns) ? columns.length : 0
+    readonly property int rowCount: Logic.rowCount(model)
+
+    property var _computedColumnWidths: []
+    property real _totalColumnWidth: 0
+
+    implicitWidth: leftPadding + rightPadding + _totalColumnWidth
+    implicitHeight: topPadding + bottomPadding + headerHeight + Math.max(visibleRowCountHint, 1) * rowHeight
+
+    onWidthChanged: updateColumnWidths()
+    onColumnsChanged: updateColumnWidths()
+    onExpandColumnsToFillChanged: updateColumnWidths()
+    onColumnSpacingChanged: updateColumnWidths()
+    onLeftPaddingChanged: updateColumnWidths()
+    onRightPaddingChanged: updateColumnWidths()
+
+    function columnWidthAt(index) {
+        if (!_computedColumnWidths || index < 0 || index >= _computedColumnWidths.length)
+            return 0;
+        return _computedColumnWidths[index];
+    }
+
+    function columnAlignment(index) {
+        var column = columns && index >= 0 && index < columns.length ? columns[index] : null;
+        var alignment = Logic.alignment(column);
+        if (alignment === "center" || alignment === "middle")
+            return Text.AlignHCenter;
+        if (alignment === "right" || Logic.isNumericAlignment(alignment))
+            return Text.AlignRight;
+        return Text.AlignLeft;
+    }
+
+    function columnTitle(index) {
+        return Logic.resolveColumnTitle(columns && columns[index], qsTr("Column %1").arg(index + 1));
+    }
+
+    function cellValue(rowObject, columnIndex) {
+        var column = columns && columnIndex >= 0 && columnIndex < columns.length ? columns[columnIndex] : null;
+        return Logic.cellValue(column, rowObject, columnIndex);
+    }
+
+    function updateColumnWidths() {
+        var available = control.width > 0 ? control.width - leftPadding - rightPadding : -1;
+        var recalculated = Logic.recalculateColumnWidths(available, columns, columnSpacing, expandColumnsToFill);
+        _computedColumnWidths = recalculated.widths;
+        _totalColumnWidth = recalculated.totalWidth;
+    }
+
+    Component.onCompleted: updateColumnWidths()
+
+    Rectangle {
+        id: frame
+        anchors.fill: parent
+        radius: 8
+        color: control.backgroundColor
+        border.color: control.gridColor
+        border.width: 1
+    }
+
+    Item {
+        id: contentArea
+        anchors {
+            left: parent.left
+            right: parent.right
+            top: parent.top
+            bottom: parent.bottom
+            leftMargin: control.leftPadding
+            rightMargin: control.rightPadding
+            topMargin: control.topPadding
+            bottomMargin: control.bottomPadding
+        }
+
+        Rectangle {
+            id: header
+            anchors {
+                left: parent.left
+                right: parent.right
+                top: parent.top
+            }
+            height: control.headerHeight
+            color: control.headerBackgroundColor
+            border.color: "transparent"
+
+            Row {
+                id: headerRow
+                anchors {
+                    left: parent.left
+                    right: parent.right
+                    top: parent.top
+                    bottom: parent.bottom
+                }
+                spacing: control.columnSpacing
+
+                Repeater {
+                    model: control.columnCount
+
+                    delegate: Item {
+                        width: control.columnWidthAt(index)
+                        height: header.height
+
+                        Text {
+                            anchors.fill: parent
+                            anchors.leftMargin: control.cellPadding
+                            anchors.rightMargin: control.cellPadding
+                            anchors.verticalCenter: parent.verticalCenter
+                            text: control.columnTitle(index)
+                            color: control.headerForegroundColor
+                            font.bold: true
+                            elide: Text.ElideRight
+                            horizontalAlignment: control.columnAlignment(index)
+                            verticalAlignment: Text.AlignVCenter
+                        }
+                    }
+                }
+            }
+
+            Rectangle {
+                anchors.left: parent.left
+                anchors.right: parent.right
+                anchors.bottom: parent.bottom
+                height: 1
+                color: control.gridColor
+            }
+        }
+
+        Rectangle {
+            id: body
+            anchors {
+                left: parent.left
+                right: parent.right
+                top: header.bottom
+                bottom: parent.bottom
+            }
+            color: "transparent"
+            clip: true
+
+            ListView {
+                id: listView
+                anchors.fill: parent
+                model: control.model
+                spacing: 0
+                clip: true
+                boundsBehavior: Flickable.StopAtBounds
+                flickableDirection: Flickable.AutoFlickIfNeeded
+                ScrollBar.vertical: ScrollBar {
+                    policy: ScrollBar.AsNeeded
+                }
+
+                delegate: Item {
+                    width: Math.max(control._totalColumnWidth, 0)
+                    height: control.rowHeight
+                    property var rowObject: Logic.rowData(control.model, index, modelData)
+
+                    Rectangle {
+                        anchors.fill: parent
+                        color: Logic.rowBackgroundForIndex(control.themePalette, index, control.alternatingRowColors)
+                    }
+
+                    Row {
+                        anchors.fill: parent
+                        spacing: control.columnSpacing
+
+                        Repeater {
+                            model: control.columnCount
+
+                            delegate: Item {
+                                width: control.columnWidthAt(index)
+                                height: parent.height
+
+                                Text {
+                                    anchors.fill: parent
+                                    anchors.leftMargin: control.cellPadding
+                                    anchors.rightMargin: control.cellPadding
+                                    text: control.cellValue(rowObject, index)
+                                    color: control.rowForegroundColor
+                                    elide: Text.ElideRight
+                                    horizontalAlignment: control.columnAlignment(index)
+                                    verticalAlignment: Text.AlignVCenter
+                                }
+                            }
+                        }
+                    }
+
+                    Rectangle {
+                        anchors.left: parent.left
+                        anchors.right: parent.right
+                        anchors.bottom: parent.bottom
+                        height: 1
+                        color: control.gridColor
+                    }
+                }
+            }
+        }
+    }
+}

--- a/qml/CustomControls/Controls/Tables/ExpandableTableLogic.js
+++ b/qml/CustomControls/Controls/Tables/ExpandableTableLogic.js
@@ -1,0 +1,200 @@
+.pragma library
+
+function defaultColumnWidth() {
+    return 160;
+}
+
+function defaultMinimumWidth() {
+    return 96;
+}
+
+function columnFlex(column) {
+    if (!column)
+        return 1;
+    var flex = column.flex;
+    if (flex === undefined || flex === null)
+        return 1;
+    return Math.max(0, flex);
+}
+
+function columnBaseWidth(column) {
+    if (!column)
+        return defaultColumnWidth();
+    if (column.width === undefined || column.width === null)
+        return defaultColumnWidth();
+    return Math.max(0, column.width);
+}
+
+function columnMinimumWidth(column) {
+    if (!column)
+        return defaultMinimumWidth();
+    if (column.minimumWidth === undefined || column.minimumWidth === null)
+        return Math.max(defaultMinimumWidth(), columnBaseWidth(column));
+    return Math.max(0, column.minimumWidth);
+}
+
+function recalculateColumnWidths(availableWidth, columns, spacing, expandColumns) {
+    var count = Array.isArray(columns) ? columns.length : 0;
+    if (count === 0) {
+        return { widths: [], totalWidth: 0 };
+    }
+
+    spacing = Math.max(0, spacing || 0);
+    var widths = new Array(count);
+    var baseWidths = new Array(count);
+    var minimumWidths = new Array(count);
+    var flexValues = new Array(count);
+    var baseWidthSum = 0;
+    var flexSum = 0;
+
+    for (var i = 0; i < count; ++i) {
+        var column = columns[i];
+        var base = columnBaseWidth(column);
+        var minimum = columnMinimumWidth(column);
+        if (minimum > base)
+            base = minimum;
+        var flex = columnFlex(column);
+
+        baseWidths[i] = base;
+        minimumWidths[i] = minimum;
+        flexValues[i] = flex;
+        baseWidthSum += base;
+        if (flex > 0)
+            flexSum += flex;
+    }
+
+    var spacingTotal = spacing * Math.max(0, count - 1);
+    var widthForColumns = availableWidth;
+    if (widthForColumns === undefined || widthForColumns === null || widthForColumns < 0)
+        widthForColumns = baseWidthSum;
+    else
+        widthForColumns = Math.max(0, widthForColumns - spacingTotal);
+
+    var extra = 0;
+    if (expandColumns && widthForColumns > baseWidthSum && flexSum > 0)
+        extra = widthForColumns - baseWidthSum;
+
+    for (var j = 0; j < count; ++j) {
+        var current = baseWidths[j];
+        if (extra > 0 && flexValues[j] > 0)
+            current += extra * (flexValues[j] / flexSum);
+        if (current < minimumWidths[j])
+            current = minimumWidths[j];
+        widths[j] = current;
+    }
+
+    var totalWidth = spacingTotal;
+    for (var k = 0; k < count; ++k)
+        totalWidth += widths[k];
+
+    return {
+        widths: widths,
+        totalWidth: totalWidth
+    };
+}
+
+function surfaceBackground(theme) {
+    return theme && theme.surface ? (theme.surface.backgroundRaised || theme.surface.background || "#ffffff") : "#ffffff";
+}
+
+function rowBackground(theme) {
+    return theme && theme.surface ? (theme.surface.backgroundRaised || "#ffffff") : "#ffffff";
+}
+
+function alternateRowBackground(theme) {
+    return theme && theme.surface ? (theme.surface.background || "#f5f5f5") : "#f5f5f5";
+}
+
+function headerBackground(theme) {
+    return theme && theme.surface ? (theme.surface.background || "#f0f0f0") : "#f0f0f0";
+}
+
+function headerForeground(theme) {
+    return theme && theme.surface ? (theme.surface.foreground || "#333333") : "#333333";
+}
+
+function rowForeground(theme) {
+    return theme && theme.surface ? (theme.surface.foreground || "#333333") : "#333333";
+}
+
+function gridColor(theme) {
+    return theme && theme.surface ? (theme.surface.border || "#d0d0d0") : "#d0d0d0";
+}
+
+function resolveColumnTitle(column, fallback) {
+    if (!column)
+        return fallback;
+    if (column.title !== undefined && column.title !== null)
+        return column.title;
+    if (column.label !== undefined && column.label !== null)
+        return column.label;
+    if (column.role !== undefined && column.role !== null)
+        return column.role;
+    return fallback;
+}
+
+function rowCount(model) {
+    if (!model)
+        return 0;
+    if (typeof model.count === "number")
+        return model.count;
+    if (typeof model.length === "number")
+        return model.length;
+    return 0;
+}
+
+function rowData(model, index, modelData) {
+    if (!model)
+        return {};
+    if (typeof model.get === "function")
+        return model.get(index) || {};
+    if (modelData !== undefined)
+        return modelData;
+    return {};
+}
+
+function cellValue(column, rowData, columnIndex) {
+    if (!column) {
+        if (rowData && typeof rowData === "object") {
+            var values = Object.keys(rowData);
+            if (columnIndex >= 0 && columnIndex < values.length)
+                return rowData[values[columnIndex]];
+        }
+        return "";
+    }
+
+    if (column.formatter !== undefined && column.formatter !== null) {
+        try {
+            return column.formatter(rowData, columnIndex);
+        } catch (err) {
+            console.warn("ExpandableTable: formatter threw", err);
+            return "";
+        }
+    }
+
+    var role = column.role;
+    if (role === undefined || role === null)
+        role = column.key;
+
+    if (role && rowData && typeof rowData === "object" && role in rowData)
+        return rowData[role];
+
+    return "";
+}
+
+function alignment(column) {
+    if (!column || column.alignment === undefined || column.alignment === null)
+        return "left";
+    return column.alignment;
+}
+
+function isNumericAlignment(alignment) {
+    return alignment === "right";
+}
+
+function rowBackgroundForIndex(theme, rowIndex, alternating) {
+    if (!alternating)
+        return rowBackground(theme);
+    return (rowIndex % 2 === 0) ? rowBackground(theme) : alternateRowBackground(theme);
+}
+

--- a/qml/CustomControls/Controls/Tabs/TabView.qml
+++ b/qml/CustomControls/Controls/Tabs/TabView.qml
@@ -1,0 +1,232 @@
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+import QtQuick.Layouts 1.15
+import "../.." as Custom
+import "TabViewLogic.js" as Logic
+
+Item {
+    id: control
+
+    property var tabs: []
+    property int currentIndex: 0
+    readonly property int tabCount: Logic.tabCount(control.tabs)
+    readonly property string currentTitle: currentIndex >= 0 ? Logic.tabTitle(control.tabs, currentIndex) : ""
+    property alias currentItem: contentLoader.item
+
+    property int themeRevision: Custom.ThemeManager.revision
+    property var themePalette: Custom.ThemeManager.palette
+
+    property color backgroundColor: {
+        themeRevision;
+        return Custom.ThemeManager.token("surface.backgroundRaised");
+    }
+    property color borderColor: {
+        themeRevision;
+        return Custom.ThemeManager.token("surface.border");
+    }
+    property color activeTabForegroundColor: {
+        themeRevision;
+        return Custom.ThemeManager.token("primary.foreground");
+    }
+    property color inactiveTabForegroundColor: {
+        themeRevision;
+        return Custom.ThemeManager.token("surface.subtle");
+    }
+    property color indicatorColor: {
+        themeRevision;
+        return Custom.ThemeManager.token("primary.background");
+    }
+    property color inactiveTabBackgroundColor: "transparent"
+
+    property real leftPadding: 16
+    property real rightPadding: 16
+    property real topPadding: 16
+    property real bottomPadding: 16
+    property real tabSpacing: 8
+    property real tabBarHeight: 40
+    property real contentSpacing: 16
+
+    signal tabActivated(int index)
+
+    implicitWidth: Math.max(320, leftPadding + rightPadding + tabRow.implicitWidth)
+    implicitHeight: Math.max(200, topPadding + bottomPadding + tabBar.height + contentArea.implicitHeight)
+
+    property var _currentContent: ({ component: null, source: "" })
+    property bool _initialized: false
+
+    function updateContent() {
+        var clamped = Logic.clampIndex(control.currentIndex, control.tabCount);
+        if (clamped !== control.currentIndex) {
+            control.currentIndex = clamped;
+            return;
+        }
+
+        if (clamped < 0) {
+            _currentContent = { component: null, source: "" };
+            return;
+        }
+
+        _currentContent = Logic.contentDefinition(control.tabs, clamped);
+    }
+
+    onTabsChanged: updateContent()
+    onTabCountChanged: updateContent()
+    onCurrentIndexChanged: {
+        var clamped = Logic.clampIndex(control.currentIndex, control.tabCount);
+        if (clamped !== control.currentIndex) {
+            control.currentIndex = clamped;
+            return;
+        }
+        updateContent();
+        if (_initialized && clamped >= 0)
+            control.tabActivated(clamped);
+    }
+
+    Component.onCompleted: {
+        _initialized = true;
+        updateContent();
+        if (control.tabCount > 0 && control.currentIndex >= 0)
+            control.tabActivated(control.currentIndex);
+    }
+
+    Rectangle {
+        id: frame
+        anchors.fill: parent
+        radius: 8
+        color: control.backgroundColor
+        border.color: control.borderColor
+        border.width: 1
+    }
+
+    Column {
+        id: layout
+        anchors {
+            fill: parent
+            leftMargin: control.leftPadding
+            rightMargin: control.rightPadding
+            topMargin: control.topPadding
+            bottomMargin: control.bottomPadding
+        }
+        spacing: control.contentSpacing
+
+        Item {
+            id: tabBar
+            width: parent.width
+            height: control.tabBarHeight
+
+            Row {
+                id: tabRow
+                anchors.fill: parent
+                anchors.bottomMargin: 3
+                spacing: control.tabSpacing
+                clip: false
+
+                Repeater {
+                    id: tabRepeater
+                    model: control.tabCount
+
+                    delegate: Button {
+                        id: tabButton
+                        required property int index
+
+                        text: Logic.tabTitle(control.tabs, index)
+                        enabled: Logic.tabEnabled(control.tabs, index)
+                        implicitHeight: tabBar.height - 3
+                        implicitWidth: Math.max(textMetrics.width + 24, 72)
+                        padding: 12
+                        hoverEnabled: true
+                        focusPolicy: Qt.TabFocus
+                        onClicked: control.currentIndex = index
+
+                        contentItem: Text {
+                            id: label
+                            text: tabButton.text
+                            color: tabButton.enabled && control.currentIndex === index
+                                   ? control.activeTabForegroundColor
+                                   : control.inactiveTabForegroundColor
+                            font.bold: control.currentIndex === index
+                            elide: Text.ElideRight
+                            horizontalAlignment: Text.AlignHCenter
+                            verticalAlignment: Text.AlignVCenter
+                            anchors.fill: parent
+                            anchors.leftMargin: 0
+                            anchors.rightMargin: 0
+                        }
+
+                        background: Rectangle {
+                            radius: 6
+                            color: control.currentIndex === index
+                                   ? control.indicatorColor
+                                   : control.inactiveTabBackgroundColor
+                            opacity: tabButton.enabled ? 1.0 : 0.5
+                        }
+
+                        Keys.onLeftPressed: {
+                            if (control.currentIndex > 0) {
+                                control.currentIndex = control.currentIndex - 1;
+                                event.accepted = true;
+                            }
+                        }
+
+                        Keys.onRightPressed: {
+                            if (control.currentIndex < control.tabCount - 1) {
+                                control.currentIndex = control.currentIndex + 1;
+                                event.accepted = true;
+                            }
+                        }
+
+                        Accessible.role: Accessible.PageTab
+                        Accessible.name: tabButton.text
+
+                        TextMetrics {
+                            id: textMetrics
+                            text: tabButton.text
+                            font: label.font
+                        }
+                    }
+                }
+            }
+
+            Rectangle {
+                anchors.left: parent.left
+                anchors.right: parent.right
+                anchors.bottom: parent.bottom
+                height: 3
+                color: control.borderColor
+                opacity: 0.5
+            }
+
+            Rectangle {
+                id: indicator
+                anchors.bottom: parent.bottom
+                height: 3
+                width: {
+                    var item = tabRepeater.itemAt(control.currentIndex);
+                    return item ? item.width : 0;
+                }
+                x: {
+                    var item = tabRepeater.itemAt(control.currentIndex);
+                    return item ? item.x : 0;
+                }
+                visible: control.tabCount > 0 && width > 0
+                color: control.indicatorColor
+                radius: height / 2
+            }
+        }
+
+        Item {
+            id: contentArea
+            width: parent.width
+            implicitHeight: contentLoader.item && contentLoader.item.implicitHeight ? contentLoader.item.implicitHeight : 0
+
+            Loader {
+                id: contentLoader
+                anchors.fill: parent
+                active: control.tabCount > 0 && control._currentContent
+                        && (control._currentContent.component || (control._currentContent.source && control._currentContent.source !== ""))
+                sourceComponent: control._currentContent.component
+                source: control._currentContent.source
+            }
+        }
+    }
+}

--- a/qml/CustomControls/Controls/Tabs/TabViewLogic.js
+++ b/qml/CustomControls/Controls/Tabs/TabViewLogic.js
@@ -1,0 +1,103 @@
+.pragma library
+
+function tabCount(tabs) {
+    if (!tabs)
+        return 0;
+
+    if (typeof tabs.count === "number")
+        return tabs.count;
+
+    if (Array.isArray(tabs))
+        return tabs.length;
+
+    if (typeof tabs.length === "number")
+        return tabs.length;
+
+    return 0;
+}
+
+function tabEntry(tabs, index) {
+    if (!tabs || index < 0)
+        return null;
+
+    if (typeof tabs.get === "function")
+        return tabs.get(index);
+
+    if (Array.isArray(tabs))
+        return tabs[index];
+
+    if (tabs[index] !== undefined)
+        return tabs[index];
+
+    return null;
+}
+
+function tabTitle(tabs, index) {
+    var entry = tabEntry(tabs, index);
+    if (!entry)
+        return qsTr("Tab %1").arg(index + 1);
+
+    if (entry.title !== undefined)
+        return entry.title;
+
+    if (entry.text !== undefined)
+        return entry.text;
+
+    if (entry.name !== undefined)
+        return entry.name;
+
+    return qsTr("Tab %1").arg(index + 1);
+}
+
+function tabEnabled(tabs, index) {
+    var entry = tabEntry(tabs, index);
+    if (!entry)
+        return false;
+
+    if (entry.enabled === undefined)
+        return true;
+
+    return !!entry.enabled;
+}
+
+function contentDefinition(tabs, index) {
+    var entry = tabEntry(tabs, index);
+    if (!entry)
+        return { component: null, source: "" };
+
+    if (entry.component)
+        return { component: entry.component, source: "" };
+
+    if (entry.sourceComponent)
+        return { component: entry.sourceComponent, source: "" };
+
+    if (entry.source)
+        return { component: null, source: entry.source };
+
+    if (entry.loader !== undefined)
+        return { component: null, source: entry.loader };
+
+    return { component: null, source: "" };
+}
+
+function clampIndex(index, count) {
+    if (count <= 0)
+        return -1;
+
+    if (index === undefined || index === null)
+        return 0;
+
+    if (index < 0)
+        return 0;
+
+    if (index >= count)
+        return count - 1;
+
+    return index;
+}
+
+exports.tabCount = tabCount;
+exports.tabTitle = tabTitle;
+exports.tabEnabled = tabEnabled;
+exports.contentDefinition = contentDefinition;
+exports.clampIndex = clampIndex;

--- a/qml/CustomControls/qmldir
+++ b/qml/CustomControls/qmldir
@@ -5,3 +5,4 @@ PrimaryButton 1.0 Controls/Buttons/PrimaryButton.qml
 TitleLabel 1.0 Controls/Labels/TitleLabel.qml
 LoadingSpinner 1.0 Controls/Indicators/LoadingSpinner.qml
 ExpandableTable 1.0 Controls/Tables/ExpandableTable.qml
+TabView 1.0 Controls/Tabs/TabView.qml

--- a/qml/CustomControls/qmldir
+++ b/qml/CustomControls/qmldir
@@ -4,3 +4,4 @@ singleton I18nManager 1.0 I18n/I18nManager.qml
 PrimaryButton 1.0 Controls/Buttons/PrimaryButton.qml
 TitleLabel 1.0 Controls/Labels/TitleLabel.qml
 LoadingSpinner 1.0 Controls/Indicators/LoadingSpinner.qml
+ExpandableTable 1.0 Controls/Tables/ExpandableTable.qml


### PR DESCRIPTION
## Summary
- drop the loading spinner GIF asset so the component no longer requires bundling a binary
- default the spinner source URL to empty so callers must supply their own image or animation

## Testing
- qmllint qml/CustomControls/Controls/Indicators/LoadingSpinner.qml *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68d5e47e1f4483228b374e0f9072bf4d