### PR TITLE
Fix loading spinner overlay caching

### DIFF
--- a/qml/CustomControls/Controls/Indicators/LoadingSpinner.qml
+++ b/qml/CustomControls/Controls/Indicators/LoadingSpinner.qml
@@ -1,5 +1,6 @@
 import QtQuick 2.15
 import QtQuick.Shapes 1.15
+import QtGraphicalEffects 1.15
 import "LoadingSpinnerLogic.js" as Logic
 
 Item {
@@ -64,6 +65,16 @@ Item {
         }
     }
 
+    ColorOverlay {
+        id: colorOverlay
+        anchors.fill: parent
+        source: arcShape
+        color: spinner.color
+        cached: false
+        visible: spinner._hasArc
+        opacity: 1.0
+    }
+
     RotationAnimator {
         id: spinAnimation
         target: spinTransform
@@ -80,13 +91,13 @@ Item {
         running: false
 
         OpacityAnimator {
-            target: arcShape
+            target: colorOverlay
             to: spinner.minOpacity
             duration: spinner.pulseDuration / 2
             easing.type: Easing.InOutQuad
         }
         OpacityAnimator {
-            target: arcShape
+            target: colorOverlay
             to: 1.0
             duration: spinner.pulseDuration / 2
             easing.type: Easing.InOutQuad
@@ -101,7 +112,7 @@ Item {
         pulseAnimation.running = shouldRun;
         if (!shouldRun) {
             spinTransform.angle = spinner._baseRotation;
-            arcShape.opacity = 1.0;
+            colorOverlay.opacity = 1.0;
         }
     }
 


### PR DESCRIPTION
## Summary
- add a ColorOverlay on the loading spinner so the tinted output stays in sync with the arc animation
- retarget the opacity pulse animation to the overlay and leave caching disabled so the spinner keeps animating

## Testing
- python -m compileall examples/gallery
- python examples/gallery/run.py *(fails: No module named 'PySide6')*

------
https://chatgpt.com/codex/tasks/task_e_68d642c563848322af0a1afdcd6b0810